### PR TITLE
Allow miner to discover validators not yet on-chain

### DIFF
--- a/crates/basilica-miner/src/config.rs
+++ b/crates/basilica-miner/src/config.rs
@@ -110,6 +110,10 @@ pub struct ValidatorAssignmentConfig {
 
     /// Specific validator hotkey to assign nodes to (required for "fixed_assignment" strategy)
     pub validator_hotkey: Option<String>,
+
+    /// Override the gRPC endpoint for the validator (e.g., "http://localhost:50052").
+    /// Useful for local development where the on-chain axon IP is spoofed.
+    pub grpc_endpoint_override: Option<String>,
 }
 
 impl Default for ValidatorAssignmentConfig {
@@ -117,6 +121,7 @@ impl Default for ValidatorAssignmentConfig {
         Self {
             strategy: default_strategy(),
             validator_hotkey: None,
+            grpc_endpoint_override: None,
         }
     }
 }

--- a/crates/basilica-miner/src/main.rs
+++ b/crates/basilica-miner/src/main.rs
@@ -105,7 +105,11 @@ impl MinerState {
                     .validator_hotkey
                     .clone()
                     .expect("validator_hotkey is required for fixed_assignment strategy");
-                Box::new(validator_discovery::FixedAssignment::new(validator_hotkey))
+                let has_override = config.validator_assignment.grpc_endpoint_override.is_some();
+                Box::new(
+                    validator_discovery::FixedAssignment::new(validator_hotkey)
+                        .allow_offline(has_override),
+                )
             }
             _ => {
                 return Err(anyhow::anyhow!(
@@ -176,7 +180,17 @@ impl MinerState {
         }
 
         // Perform one-time chain registration (Bittensor network presence)
-        self.chain_registration.register_startup().await?;
+        match self.chain_registration.register_startup().await {
+            Ok(()) => {}
+            Err(e) if self.config.bittensor.common.network == "local" => {
+                warn!(
+                    "serve_axon failed on local network (non-fatal): {}. \
+                     Use sudo_as on the local chain to pre-register the axon.",
+                    e
+                );
+            }
+            Err(e) => return Err(e),
+        }
 
         // Log the discovered UID
         if let Some(uid) = self.chain_registration.get_discovered_uid().await {
@@ -189,15 +203,22 @@ impl MinerState {
 
         // One-shot validator discovery at startup
         let discovered = self.validator_discovery.run_discovery().await?;
+
+        // Allow config to override the gRPC endpoint (for local dev with spoofed IPs)
+        let grpc_endpoint = self
+            .config
+            .validator_assignment
+            .grpc_endpoint_override
+            .clone()
+            .unwrap_or(discovered.grpc_endpoint);
         info!(
-            grpc_endpoint = %discovered.grpc_endpoint,
+            grpc_endpoint = %grpc_endpoint,
             "Validator discovered, starting bid manager"
         );
 
         // Start bid manager (owns registration lifecycle: register, health checks)
         let bid_manager = self.bid_manager.clone();
         let bid_manager_shutdown_rx = shutdown_rx.clone();
-        let grpc_endpoint = discovered.grpc_endpoint;
         let bid_manager_handle = tokio::spawn(async move {
             if let Err(e) = bid_manager
                 .run(grpc_endpoint, bid_manager_shutdown_rx)

--- a/crates/basilica-miner/src/validator_discovery.rs
+++ b/crates/basilica-miner/src/validator_discovery.rs
@@ -141,20 +141,23 @@ impl ValidatorDiscovery {
             .set_assigned_validator(&validator.hotkey)
             .await;
 
-        // Construct gRPC endpoint from the validator's axon IP and configured bid_grpc_port
-        let axon_endpoint = validator.axon_endpoint.as_ref().ok_or_else(|| {
-            anyhow::anyhow!(
-                "Validator {} has no axon endpoint; cannot construct gRPC endpoint",
+        // Construct gRPC endpoint from the validator's axon IP and configured bid_grpc_port.
+        // If the validator has no axon (e.g. synthesized placeholder), use a dummy endpoint
+        // that will be overridden by grpc_endpoint_override in the caller.
+        let grpc_endpoint = if let Some(ref axon_endpoint) = validator.axon_endpoint {
+            let axon_url = url::Url::parse(axon_endpoint)
+                .map_err(|e| anyhow::anyhow!("Invalid axon endpoint URL: {}", e))?;
+            let host = axon_url
+                .host_str()
+                .ok_or_else(|| anyhow::anyhow!("No host in axon endpoint"))?;
+            format!("http://{}:{}", host, self.bid_grpc_port)
+        } else {
+            warn!(
+                "Validator {} has no axon endpoint; gRPC endpoint must be provided via override",
                 validator.hotkey
-            )
-        })?;
-
-        let axon_url = url::Url::parse(axon_endpoint)
-            .map_err(|e| anyhow::anyhow!("Invalid axon endpoint URL: {}", e))?;
-        let host = axon_url
-            .host_str()
-            .ok_or_else(|| anyhow::anyhow!("No host in axon endpoint"))?;
-        let grpc_endpoint = format!("http://{}:{}", host, self.bid_grpc_port);
+            );
+            String::from("http://0.0.0.0:0")
+        };
 
         let discovered = DiscoveredValidator {
             hotkey: validator.hotkey.clone(),
@@ -173,11 +176,23 @@ impl ValidatorDiscovery {
 /// Fixed assignment strategy - assigns all nodes to a specific validator
 pub struct FixedAssignment {
     validator_hotkey: String,
+    /// When true, synthesize a placeholder validator if not found on-chain.
+    /// This allows grpc_endpoint_override to work even when the validator
+    /// has not registered its axon on-chain.
+    allow_offline: bool,
 }
 
 impl FixedAssignment {
     pub fn new(validator_hotkey: String) -> Self {
-        Self { validator_hotkey }
+        Self {
+            validator_hotkey,
+            allow_offline: false,
+        }
+    }
+
+    pub fn allow_offline(mut self, allow: bool) -> Self {
+        self.allow_offline = allow;
+        self
     }
 }
 
@@ -194,6 +209,18 @@ impl AssignmentStrategy for FixedAssignment {
             .find(|v| v.hotkey == self.validator_hotkey)
         {
             Ok(Some(validator))
+        } else if self.allow_offline {
+            warn!(
+                "Validator {} not found on-chain; synthesizing placeholder (grpc_endpoint_override required)",
+                self.validator_hotkey
+            );
+            Ok(Some(ValidatorInfo {
+                uid: 0,
+                hotkey: self.validator_hotkey.clone(),
+                coldkey: String::new(),
+                stake: 0,
+                axon_endpoint: None,
+            }))
         } else {
             warn!(
                 "Validator with hotkey {} not found in active validators",

--- a/crates/basilica-validator/src/service.rs
+++ b/crates/basilica-validator/src/service.rs
@@ -196,7 +196,17 @@ impl ValidatorService {
         bittensor_service: Arc<BittensorService>,
     ) -> Result<ChainRegistration> {
         let chain_registration = ChainRegistration::new(&self.config, bittensor_service).await?;
-        chain_registration.register_startup().await?;
+        match chain_registration.register_startup().await {
+            Ok(()) => {}
+            Err(e) if self.config.bittensor.common.network == "local" => {
+                tracing::warn!(
+                    "serve_axon failed on local network (non-fatal): {}. \
+                     Use sudo_as on the local chain to pre-register the axon.",
+                    e
+                );
+            }
+            Err(e) => return Err(e),
+        }
         Ok(chain_registration)
     }
 


### PR DESCRIPTION
## Summary
- Adds `grpc_endpoint_override` config field so miners can connect to validators whose axon IP isn't registered on-chain
- `FixedAssignment` strategy gains `allow_offline` mode that synthesizes a placeholder validator when the target hotkey isn't in the metagraph
- `run_discovery()` handles missing axon endpoints gracefully instead of erroring
- `serve_axon` failure is non-fatal on local networks (both miner and validator)

## Context
When bootstrapping a new subnet deployment, the validator may not have registered its axon on-chain yet. This prevents the miner from discovering it via metagraph lookup. These changes allow the miner to connect directly via config override while the on-chain registration catches up.

## Test plan
- [ ] Miner starts with `grpc_endpoint_override` set and `fixed_assignment` strategy
- [ ] Miner connects to validator gRPC even when validator isn't in metagraph
- [ ] Existing behavior unchanged when `grpc_endpoint_override` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)