### PR TITLE
Add policy doc and status block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 2026-04-14
+
+- Published v0 policy doc (docs/policy.md)
+- Added status block to README
+
+## 2026-04-13
+
+- Forked from upstream Basilica
+- Modified validator to run against self-hosted incentive API
+- Rebuilt API endpoints so miners and validators can discover each other on this fork
+- Opened PR #1: grpc_endpoint_override config, allow_offline mode on FixedAssignment, non-fatal serve_axon on local nets
+- Published live dashboard at polaris.computer/substrate

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@
   <a href="docs/architecture.md">Architecture</a>
 </p>
 
+## Status
+
+Validator running. Not setting weights yet (stake threshold).
+See [docs/policy.md](docs/policy.md) for how this works.
+Live dashboard: https://polaris.computer/substrate
+
 ## Why
 
 Bittensor needs a compute layer. Not a product. Not a platform with a token narrative. A substrate -- infrastructure that miners provide, validators verify, and applications consume.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Live dashboard: https://polaris.computer/substrate
 
 Bittensor needs a compute layer. Not a product. Not a platform with a token narrative. A substrate -- infrastructure that miners provide, validators verify, and applications consume.
 
-This project is a fork of [Basilica](https://github.com/tplr-ai/basilica), one of the strongest compute codebases ever built on Bittensor. When its original team walked away in April 2026, the architecture survived. The code was sound. The miners and builders who believed in it stayed.
+This project is a fork of [Basilica](https://github.com/one-covenant/basilica), one of the strongest compute codebases ever built on Bittensor. When its original team walked away in April 2026, the architecture survived. The code was sound. The miners and builders who believed in it stayed.
 
 Substrate carries that work forward.
 
@@ -57,7 +57,7 @@ Substrate creates a trustless marketplace for GPU compute by:
 
 ## Origins
 
-Forked from [tplr-ai/basilica](https://github.com/tplr-ai/basilica) under MIT License. Original work by the Basilica contributors. Continued by the community.
+Forked from [one-covenant/basilica](https://github.com/one-covenant/basilica) under MIT License. Original work by the Basilica contributors. Continued by the community.
 
 ## License
 

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -1,0 +1,50 @@
+# How Substrate works (draft)
+
+Status: v0, will evolve. Published 2026-04-14.
+
+## What this is
+
+Substrate (SN39) is an open compute network on Bittensor. Miners contribute GPU capacity, validators verify it, the chain distributes emissions based on validator weights.
+
+We (Polaris) run a validator on SN39 and publish the incentive configuration it reads. The configuration lives at:
+
+    GET https://api.polaris.computer/v1/incentive/config
+
+Other validators running our code read from the same endpoint.
+
+## What we commit to
+
+While we're operating this config:
+
+- **No forced burn.** The only burn is the chain-level residual when miner payouts don't fill the emission capacity. No operator-set tax on top.
+- **Category independence.** Earnings in one GPU category don't affect another.
+- **No retroactive changes.** Config updates affect earnings from the update forward. Already-vested earnings stay vested.
+- **Slashing is narrow.** Only triggers on permanent node loss during an active rental. Transient failures don't slash.
+- **Changes are announced.** Material config changes get posted publicly before they take effect.
+- **Changelog is public.** Every change gets recorded below.
+
+## What we don't claim
+
+- We don't own the subnet. We run a validator and publish a config.
+- We're not setting weights yet (low stake). Solving that soon.
+- These commitments apply while we're operating the config. Governance of the subnet long-term is a community question.
+- **We do not recommend staking to subnet 39 at this time.** There is uncertainty about the keys from the prior operators. Wait for clarity before committing stake.
+
+## Current status
+
+- Validator running: yes
+- Setting weights: no (stake threshold)
+- Miners registered: small number, growing
+- Active rentals: none yet
+
+See live dashboard: https://polaris.computer/substrate
+
+## How to propose changes
+
+- Open an issue in this repo
+- Post in the Substrate Discord
+- DM a maintainer
+
+## Changelog
+
+- 2026-04-14: v0 published.


### PR DESCRIPTION
Publishes v0 policy doc, adds status block to README, creates CHANGELOG with fork history. Non-code changes. Ready for review.