### PR TITLE
Rename project from Substrate to Cathedral

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="logo.png" alt="Substrate" width="200" />
+  <img src="logo.png" alt="Cathedral" width="200" />
 </p>
 
-# <p align="center">Substrate</p>
+# <p align="center">Cathedral</p>
 
 <p align="center">
   <em>Compute Layer for Bittensor</em>
@@ -13,51 +13,51 @@
 <p align="center">
   <a href="docs/miner.md">Miner</a> •
   <a href="docs/validator.md">Validator</a> •
-  <a href="docs/architecture.md">Architecture</a>
+  <a href="docs/architecture.md">Architecture</a> •
+  <a href="docs/policy.md">Policy</a>
 </p>
 
 ## Status
 
 Validator running. Not setting weights yet (stake threshold).
-See [docs/policy.md](docs/policy.md) for how this works.
+See [docs/policy.md](docs/policy.md) for how the incentive mechanism works.
 Live dashboard: https://polaris.computer/substrate
 
 ## Why
 
-Bittensor needs a compute layer. Not a product. Not a platform with a token narrative. A substrate -- infrastructure that miners provide, validators verify, and applications consume.
+Bittensor needs a compute layer. Not a product. Not a platform with a token narrative. A base layer that miners provide, validators verify, and applications consume.
 
-This project is a fork of [Basilica](https://github.com/one-covenant/basilica), one of the strongest compute codebases ever built on Bittensor. When its original team walked away in April 2026, the architecture survived. The code was sound. The miners and builders who believed in it stayed.
+Cathedral is a fork of [Basilica](https://github.com/one-covenant/basilica), one of the strongest compute codebases ever built on Bittensor. When its original team walked away in April 2026, the architecture survived. The code was sound. The miners and builders who believed in it stayed.
 
-Substrate carries that work forward.
+Cathedral carries that work forward.
 
 ## Overview
 
-Substrate creates a trustless marketplace for GPU compute by:
+Cathedral creates a trustless marketplace for GPU compute by:
 
-- **Hardware Verification**: Binary validation system for secure GPU verification and profiling
-- **Remote Validation**: SSH-based verification of computational tasks and hardware specifications
-- **Bittensor Integration**: Native participation in Bittensor's consensus mechanism with weight allocation
-- **Fleet Management**: Efficient orchestration of distributed GPU resources with assignment management
-- **Substrate API Gateway**: Smart HTTP gateway providing load-balanced access to the validator network
+- **Hardware Verification**: Validates GPUs through a mix of binary challenges and SSH-based discovery, with cryptographic attestation where available
+- **Remote Validation**: SSH-based verification of hardware, network, storage, and container runtime
+- **Bittensor Integration**: Native participation in consensus, weight-setting, and emission distribution on Subnet 39
+- **Fleet Management**: Orchestration of distributed GPU nodes across miners, with exclusive access enforcement
+- **Incentive Engine**: CU and RU dual-stream payouts, linear vesting, and category-based dilution — documented in [docs/policy.md](docs/policy.md)
 
 ## Key Components
 
-- **Validator**: Verifies hardware capabilities, maintains GPU profiles, and scores miner performance
-- **Miner**: Manages GPU executor fleets, handles assignments, and serves compute requests via Axon
-- **Executor**: GPU machine agent with container management, system monitoring, and secure task execution
-- **Substrate API**: HTTP gateway with authentication, caching, rate limiting, and request aggregation
-- **Substrate Common**: Shared utilities including crypto, SSH management, storage, and configuration
+- **Validator**: Verifies hardware, scores miners, computes weights, submits to chain
+- **Miner**: Registers GPU nodes with validators, deploys validator SSH keys, serves health checks
+- **Executor**: GPU machine agent for container lifecycle, system monitoring, and secure task execution
+- **API Gateway**: HTTP gateway with authentication, caching, and request aggregation
+- **Common**: Shared utilities — crypto, SSH, persistence, identity, config
 - **Protocol**: gRPC/protobuf definitions for inter-component communication
-- **Bittensor**: Network integration for registration, discovery, and weight management
 
 ## Network Information
 
 - **Mainnet**: Bittensor Finney, Subnet 39
-- **Chain Endpoint**: `wss://entrypoint-finney.opentensor.ai:443` (mainnet)
+- **Chain Endpoint**: `wss://entrypoint-finney.opentensor.ai:443`
 
 ## Origins
 
-Forked from [one-covenant/basilica](https://github.com/one-covenant/basilica) under MIT License. Original work by the Basilica contributors. Continued by the community.
+Forked from [one-covenant/basilica](https://github.com/one-covenant/basilica) under the MIT License. The original Basilica code was written by the Covenant team between 2025 and 2026. Their work is what made this possible.
 
 ## License
 

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -1,10 +1,10 @@
-# How Substrate works (draft)
+# How Cathedral works (draft)
 
 Status: v0, will evolve. Published 2026-04-14.
 
 ## What this is
 
-Substrate (SN39) is an open compute network on Bittensor. Miners contribute GPU capacity, validators verify it, the chain distributes emissions based on validator weights.
+Cathedral (SN39) is an open compute network on Bittensor. Miners contribute GPU capacity, validators verify it, the chain distributes emissions based on validator weights.
 
 We (Polaris) run a validator on SN39 and publish the incentive configuration it reads. The configuration lives at:
 
@@ -42,7 +42,7 @@ See live dashboard: https://polaris.computer/substrate
 ## How to propose changes
 
 - Open an issue in this repo
-- Post in the Substrate Discord
+- Post in the Cathedral Discord
 - DM a maintainer
 
 ## Changelog


### PR DESCRIPTION
Renames the project from Substrate to Cathedral across README.md and docs/policy.md. Repo has already been renamed on GitHub (substrate → cathedral). Binary names and internal crate names are handled separately in #7.

## Changes

- README.md: Substrate → Cathedral throughout, refreshed overview and key components copy
- docs/policy.md: title and Discord reference updated

## Out of scope

- Binary rename (cathedral-validator / cathedral-miner) — in #7
- Full crate rename (basilica-* → cathedral-*) — future work, issue #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)