### PR TITLE
changelog: 2026-04-17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 2026-04-17
+
+### Site
+
+- **cathedral.computer is live.** Two-pane dashboard streaming validator and miner logs side by side, with cross-stream event pairing (registration, ssh-key deploy, verification) highlighted together.
+- Added `/mine` quickstart — prerequisites, validator endpoint, `miner.toml`, build steps, expected logs, known limitations, plain disclaimer.
+- Added `/roadmap` — three acts (`baseline` / `loops` / `ecosystem`) pulled live from GitHub issues. Acts are the arc, issues under them are subject to change.
+- Added `/changelog` — this file, rendered on-site.
+- Light mode + readability pass — warm paper theme, bigger log font, quieter chrome, hairline separators. Theme preference persists and respects `prefers-color-scheme`.
+- Home page stanza framing the project as a commons.
+
+### Project organization
+
+- Created three GitHub milestones: `act 1 · baseline`, `act 2 · loops`, `act 3 · ecosystem`. Existing act-labelled issues moved into the matching milestone so the grouping is native to GitHub (#11 #12 #13 #14 #15 #16 #17 #18 #19).
+- Site deploys are reproducible from the repo now — `wrangler.jsonc` checked in (previously ad-hoc).
+
+### Backend (polariscomputer)
+
+- New `/api/substrate/miner/logs` endpoint mirroring the validator log endpoint; powers the miner pane on the dashboard.
+- Log-tail security hardening — explicit allowlist on log paths, shell-quoted path argument. Guards against operator misconfig leaking wallet or ssh key files via the log endpoint.
+- CORS origins extended to cathedral.computer.
+
+### On-chain (SN39)
+
+- Validator (UID 123) and miner (UID 115) running end-to-end on a single Hetzner box with one A100 GPU node attached.
+- First miner scored 1.0 by the validator.
+- Weight-setting still parked — we're below the ~14k α permit threshold on SN39. CUs accrue; emissions flow once weights unlock.
+
+### Known rough edges, shipped honestly
+
+- Binary GPU attestation is off; verification runs over SSH via `nvidia-smi`. Spoofable, honor-system for now — will swap in the prover binary when ready.
+- Only A100 and H100 priced today.
+- No rental marketplace yet — that's act 2.
+
 ## 2026-04-16
 
 - Project renamed from Substrate to Cathedral. Repo moved to github.com/bigailabs/cathedral (#8)


### PR DESCRIPTION
Records today's shipping: site launch, roadmap, mine page, light mode, readability pass, backend log endpoint, milestones, first verified miner at 1.0.