### PR TITLE
fix(validator): eliminate SSH scheduler deadlock

### DIFF
--- a/crates/basilica-common/src/ssh/connection.rs
+++ b/crates/basilica-common/src/ssh/connection.rs
@@ -6,8 +6,9 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::time::Duration;
+use tokio::process::Command;
 use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
 
@@ -603,8 +604,19 @@ impl StandardSshClient {
 
         debug!("Executing SSH command: {:?}", cmd);
 
-        let output = cmd
-            .output()
+        // Wrap in tokio::time::timeout so a hanging ssh child (network black-hole,
+        // unreachable node, stuck handshake) can't block this await indefinitely
+        // and starve the verification scheduler. Upstream Basilica hit this class
+        // of bug four times (PRs #58, #112, #116, #122); we are re-closing the gap
+        // after a refactor landed a blocking std::process::Command here.
+        let output = timeout(self.config.execution_timeout, cmd.output())
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "SSH command timed out after {:?}",
+                    self.config.execution_timeout
+                )
+            })?
             .map_err(|e| anyhow::anyhow!("Failed to execute SSH command: {}", e))?;
 
         if output.status.success() {
@@ -785,7 +797,7 @@ impl SshFileTransferManager for StandardSshClient {
         debug!("Executing SCP command: {:?}", cmd);
 
         let result = timeout(self.config.execution_timeout, async {
-            let output = cmd.output()?;
+            let output = cmd.output().await?;
             if output.status.success() {
                 Ok(())
             } else {
@@ -861,7 +873,7 @@ impl SshFileTransferManager for StandardSshClient {
         debug!("Executing SCP download command: {:?}", cmd);
 
         let result = timeout(self.config.execution_timeout, async {
-            let output = cmd.output()?;
+            let output = cmd.output().await?;
             if output.status.success() {
                 Ok(())
             } else {

--- a/crates/basilica-validator/src/miner_prover/scheduler.rs
+++ b/crates/basilica-validator/src/miner_prover/scheduler.rs
@@ -397,9 +397,31 @@ async fn spawn_verification_task(
             "[EVAL_FLOW] Starting verification workflow",
         );
 
-        let result = verification_engine
-            .execute_verification_workflow(&task)
-            .await;
+        // Workflow-wide timeout independent of per-step SSH timeouts: a cascade of
+        // slow/hung steps can still accumulate beyond any reasonable verification
+        // window. Cap at 10 minutes so one unreachable miner cannot hold a task
+        // handle open forever and starve cleanup.
+        let workflow_timeout = std::time::Duration::from_secs(600);
+        let result = match tokio::time::timeout(
+            workflow_timeout,
+            verification_engine.execute_verification_workflow(&task),
+        )
+        .await
+        {
+            Ok(inner) => inner,
+            Err(_) => {
+                error!(
+                    miner_uid = task.miner_uid,
+                    task_id = %task_id,
+                    "[EVAL_FLOW] Verification workflow exceeded {:?} — aborting task {}",
+                    workflow_timeout, task_id
+                );
+                Err(anyhow::anyhow!(
+                    "verification workflow timed out after {:?}",
+                    workflow_timeout
+                ))
+            }
+        };
 
         match result {
             Ok(verification_result) => {


### PR DESCRIPTION
## Summary

- Scheduler stops running verification cycles after the first tick. Weight-setter keeps going; `execute_verification_workflow` never returns. McDee's UID 155 is stuck at `declared` indefinitely, and any other declared miner is blocked behind it.
- Root cause: `execute_ssh_command` in `crates/basilica-common/src/ssh/connection.rs` was using blocking `std::process::Command` + sync `.output()` inside an `async fn`. Every hung ssh child (unreachable node, stuck handshake, dead TCP) blocks a tokio worker for the full child lifetime with no upper bound.
- Fix: swap to `tokio::process::Command`, wrap `.output()` in `tokio::time::timeout(self.config.execution_timeout, ...)`, and update the scp upload/download paths to `cmd.output().await`. Add a 10-min workflow-wide timeout in `spawn_verification_task` so a cascade of slow steps can't hold a task handle open forever either.

## Why this keeps happening

Upstream Basilica hit this exact bug family four times:

- #58 (2025-07-29) - `ssh-keygen` to `/dev/null` deadlocked the validator
- #112 (2025-09-01) - first-connection SSH host-key prompt hang
- #116 (2025-09-03) - resource-management overhaul: process groups, SIGTERM/SIGKILL, `spawn_blocking`, semaphore cap
- #122 (2025-09-16) - lock-across-await + piped stdout/stderr buffer deadlock
- #419 (2026-04-09) - still mopping up zombie reaping at the OS level

Refs: `~/Documents/PROJECTS/polariscomputer/research/basilica-history/LESSONS.md`

## Test plan

- [x] `cargo check -p basilica-common -p basilica-validator` passes locally
- [ ] Build on VPS, systemctl restart cathedral-validator
- [ ] Confirm `[EVAL_FLOW]` entries for UID 155 appear in `/root/cathedral-logs/validator.log` within 10 min of the next scheduler tick
- [ ] Leave running overnight; verify repeated cycles (not a single tick then silence)
- [ ] Confirm McDee's UID 155 transitions `declared` -> `verified` on the site's Miners Register

Closes #28.