### PR TITLE
fix(validator): admit home-ownable nodes when binary attestation disabled

### DIFF
--- a/crates/basilica-validator/src/miner_prover/validation_strategy.rs
+++ b/crates/basilica-validator/src/miner_prover/validation_strategy.rs
@@ -933,13 +933,25 @@ impl ValidationNode {
                 .as_ref()
                 .map(|m| !m.is_banned)
                 .unwrap_or(true);
-            quality_validations_successful =
-                docker_result.is_some() && nat_successful && not_banned;
+
+            // Cathedral pivoted to home-ownable compute (issue #24). Home miners
+            // are behind NAT and cannot serve inbound HTTP from a random port,
+            // so the upstream Basilica NAT check is a blanket disqualifier for
+            // our target audience. When binary attestation is disabled (our
+            // fork's default until prover binaries ship), we trust SSH reach
+            // + docker GPU runtime as sufficient proof of a live node. NAT
+            // is still run for diagnostics but no longer blocks admission.
+            let nat_required = binary_config.is_some();
+            quality_validations_successful = if nat_required {
+                docker_result.is_some() && nat_successful && not_banned
+            } else {
+                docker_result.is_some() && not_banned
+            };
 
             if docker_result.is_none() {
                 failure_reasons.push("docker_validation_failed".to_string());
             }
-            if nat_result.is_none() || !nat_successful {
+            if nat_required && (nat_result.is_none() || !nat_successful) {
                 failure_reasons.push("nat_validation_failed".to_string());
             }
             if storage_result.is_none() {

--- a/crates/basilica-validator/src/miner_prover/verification.rs
+++ b/crates/basilica-validator/src/miner_prover/verification.rs
@@ -1283,7 +1283,19 @@ impl VerificationEngine {
             }
         }?;
 
-        if result.validation_type == ValidationType::Full {
+        // The declared-GPU enforcement check cross-references the miner's
+        // declared gpu_category against what the binary validator detected.
+        // On cathedral we run with binary attestation disabled (issue #24),
+        // so "detected" comes from an SSH nvidia-smi scrape whose string
+        // format does not line up with the legacy GpuCategory normalizer —
+        // e.g. a miner declares RTX_4090 but normalize_gpu_category folds
+        // anything non-datacenter into Other(raw), and string-equality
+        // against a detected "NVIDIA GeForce RTX 4090" always fails.
+        // Skipping this check when binary validation is disabled matches
+        // #24's accepted trust-the-SSH-side tradeoff until prover binaries
+        // ship. Re-enable the moment binary_validation is configured.
+        let binary_validation_enabled = self.config.binary_validation.is_some();
+        if result.validation_type == ValidationType::Full && binary_validation_enabled {
             self.enforce_declared_gpu_claims_for_full_validation(miner_uid, &mut result)
                 .await?;
         }


### PR DESCRIPTION
## Summary

Two upstream Basilica checks block every home miner on our fork:

1. **NAT** — we currently require an inbound HTTP probe to succeed on the miner's advertised IP/port. Home routers block this by default. UID 155 (McDee) fails here: \`HTTP request failed: error sending request for url (http://68.52.239.238:32769/test.txt): operation timed out\`.
2. **GPU-declaration enforcement** — compares miner-declared \`gpu_category\` to the binary validator's detected category. With binary disabled, detection comes from an SSH \`nvidia-smi\` scrape, and the \`GpuCategory\` normalizer only knows A100/H100/H200/B200/B300. Every new consumer GPU (RTX_4090, RTX_5090, APPLE_M_*) falls into \`Other(raw)\` and string-mismatches.

With binary attestation disabled (our default), both checks reject nodes that are otherwise perfectly fine. Per issue #24 we explicitly accept \"trust the SSH side until prover binaries ship.\"

## Changes

- \`validation_strategy.rs::execute_full_validation\`: when \`binary_config.is_none()\`, \`quality_validations_successful = docker_result.is_some() && not_banned\` (drop NAT requirement). NAT is still run and logged for diagnostics.
- \`verification.rs\`: skip \`enforce_declared_gpu_claims_for_full_validation\` when binary validation is disabled.
- Both guards re-enable automatically when \`binary_validation\` config is populated — no config knob, no backwards incompat.

## Test plan

- [x] \`cargo check -p basilica-validator\` passes
- [ ] VPS build, systemctl restart cathedral-validator
- [ ] UID 155 reaches \`status=verified\` in \`miner_nodes\` within two scheduler cycles (~20 min)
- [ ] Site home page shows 'Verified GPU nodes' row tick to 1
- [ ] Weight-setter picks up UID 155 on next cycle

Refs #24. Depends conceptually on (but doesn't block) #30 (loopback/RFC1918 register-time reject).