### PR TITLE
fix(miner): accept any non-empty gpu_category (home-ownable pivot)

### DIFF
--- a/crates/basilica-miner/src/node_manager.rs
+++ b/crates/basilica-miner/src/node_manager.rs
@@ -69,14 +69,21 @@ impl<'de> Deserialize<'de> for NodeConfig {
     {
         let raw = NodeConfigRaw::deserialize(deserializer)?;
 
-        // Validate gpu_category is a known GPU type
-        let gpu_cat: GpuCategory = raw.gpu_category.parse().unwrap(); // Infallible
-        if matches!(&gpu_cat, GpuCategory::Other(_)) {
-            return Err(serde::de::Error::custom(format!(
-                "GPU type '{}' is not supported",
-                raw.gpu_category
-            )));
+        // Cathedral pivoted to home-ownable compute (cathedral#24). The legacy
+        // GpuCategory enum only recognises data-center SKUs (A100/H100/H200/
+        // B200/B300); rejecting everything else locks out every consumer card,
+        // workstation card, Apple Silicon box, and DGX Spark that the subnet
+        // is now built for. Pricing lives on the validator side keyed by the
+        // raw string; the only requirement here is that the category isn't
+        // empty. Keep GpuCategory parsing so known data-center strings still
+        // normalise the same way (e.g. "nvidia a100" → "A100").
+        let raw_category = raw.gpu_category.trim();
+        if raw_category.is_empty() {
+            return Err(serde::de::Error::custom(
+                "gpu_category must not be empty",
+            ));
         }
+        let gpu_cat: GpuCategory = raw_category.parse().unwrap(); // Infallible
 
         Ok(NodeConfig {
             host: raw.host,


### PR DESCRIPTION
## Summary

- NodeConfig deserializer rejected any gpu_category outside A100/H100/H200/B200/B300. That blocks every consumer GPU and every other home-ownable class that issue #24 explicitly added pricing for.
- Loosens the guard to \"must not be empty\" — pricing lives on the validator (#24), so the miner shouldn't gatekeep.
- Still runs the raw string through GpuCategory::from_str so legacy strings like \"nvidia a100\" still normalise to \"A100\".

## Test plan

- [x] cargo build --release -p basilica-miner passes
- [ ] Ship binary to the Lium 5090 box + boot miner with gpu_category = \"RTX_5090\"
- [ ] Confirm RegisterBid reaches our validator with RTX_5090 and verification proceeds

Refs cathedral#24.