### PR TITLE
fix(validator): accept any non-empty gpu_category (home-ownable pivot)

### DIFF
--- a/crates/basilica-validator/src/api/routes/rentals.rs
+++ b/crates/basilica-validator/src/api/routes/rentals.rs
@@ -208,15 +208,14 @@ pub async fn start_rental(
     State(state): State<ApiState>,
     Json(request): Json<StartRentalRequest>,
 ) -> Result<Json<RentalResponse>, StatusCode> {
-    // Parse and validate gpu_category using GpuCategory enum
-    let gpu_category: GpuCategory = request.gpu_category.parse().unwrap(); // Infallible
-    if matches!(&gpu_category, GpuCategory::Other(_)) {
-        error!(
-            gpu_category = %request.gpu_category,
-            "[RENTAL_FLOW] GPU type '{}' is not supported", request.gpu_category
-        );
+    // Parse gpu_category; accept any non-empty value. Cathedral prices by
+    // raw category string (#24) so consumer GPUs and Apple Silicon are
+    // legitimate — don't reject them here.
+    if request.gpu_category.trim().is_empty() {
+        error!("[RENTAL_FLOW] gpu_category is empty");
         return Err(StatusCode::BAD_REQUEST);
     }
+    let gpu_category: GpuCategory = request.gpu_category.parse().unwrap(); // Infallible
 
     info!(
         gpu_category = %gpu_category,

--- a/crates/basilica-validator/src/cli/handlers/rental.rs
+++ b/crates/basilica-validator/src/cli/handlers/rental.rs
@@ -119,11 +119,11 @@ async fn handle_start_rental(
     memory_mb: Option<i64>,
     storage_mb: Option<i64>,
 ) -> Result<()> {
-    // Validate gpu_category is a known GPU type
-    let gpu_cat: GpuCategory = gpu_category.parse().unwrap(); // Infallible
-    if matches!(&gpu_cat, GpuCategory::Other(_)) {
-        anyhow::bail!("GPU type '{}' is not supported", gpu_category);
+    // Cathedral prices by raw category string (#24); accept any non-empty.
+    if gpu_category.trim().is_empty() {
+        anyhow::bail!("gpu_category is required");
     }
+    let gpu_cat: GpuCategory = gpu_category.parse().unwrap(); // Infallible
 
     info!(
         "Starting rental for {} x {} GPU(s)",

--- a/crates/basilica-validator/src/grpc/registration.rs
+++ b/crates/basilica-validator/src/grpc/registration.rs
@@ -205,14 +205,12 @@ impl MinerRegistration for RegistrationService {
             if node.gpu_category.trim().is_empty() {
                 return Err(Status::invalid_argument("gpu_category is required"));
             }
-            // Validate gpu_category is a known GPU type
+            // Normalize the category (e.g. "nvidia a100" → "A100") but accept
+            // any non-empty string. Cathedral prices by raw category string
+            // (issue #24), so rejecting Other(raw) locks out every consumer
+            // GPU, workstation card, Apple Silicon box, and DGX Spark — the
+            // exact audience we pivoted to serve.
             let gpu_cat: GpuCategory = node.gpu_category.parse().unwrap(); // Infallible
-            if matches!(&gpu_cat, GpuCategory::Other(_)) {
-                return Err(Status::invalid_argument(format!(
-                    "GPU type '{}' is not supported",
-                    node.gpu_category
-                )));
-            }
             if node.gpu_count == 0 {
                 return Err(Status::invalid_argument("gpu_count must be greater than 0"));
             }


### PR DESCRIPTION
## Summary

Mirror of cathedral#32 on the validator side. Three entry points hard-rejected any GpuCategory::Other(_):

- \`grpc/registration.rs\` — RegisterBid
- \`api/routes/rentals.rs\` — start_rental
- \`cli/handlers/rental.rs\` — start_rental

Cathedral prices by raw category string (issue #24), so every consumer GPU, workstation card, Apple Silicon tier, and DGX Spark falls into Other(raw). Our validator was literally refusing the pivot we built pricing for. Witness: our own UID 115 miner on a real RTX 5090 just got \`RegisterBid RPC failed: GPU type 'RTX_5090' is not supported\`.

Keeps the empty-string guard; drops the Other(_) guard. GpuCategory parsing still used to normalise data-center strings (e.g. \"nvidia a100\" → \"A100\").

## Test plan

- [x] cargo check -p basilica-validator passes
- [ ] Ship to VPS, systemctl restart cathedral-validator
- [ ] Our miner on 91.224.44.207 (UID 115, RTX_5090) successfully RegisterBids
- [ ] Row appears in \`miner_nodes\` and site funnel ticks to 1 registered, then 1 verified