### PR TITLE
refactor(cli): cathedral-cli is miner/validator ops only

### DIFF
--- a/scripts/cathedral-cli.py
+++ b/scripts/cathedral-cli.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
 """
-cathedral-cli — quick command line for listing machines and running rentals
-on cathedral (Bittensor SN39).
+cathedral-cli — operator tooling for Cathedral (Bittensor SN39).
+
+Scope: miner and validator operations only. Cathedral is the subnet;
+user-facing compute rental lives on polaris.computer (polaris-cli).
 
 Usage:
-    cathedral-cli list                            # show all available machines
-    cathedral-cli list --category RTX_5090        # filter by GPU category
-    cathedral-cli list --max-price-cents 50       # under $0.50/GPU/hr
-    cathedral-cli rent <node_id> --ssh-key ~/.ssh/id_ed25519.pub --max-cents 45
-    cathedral-cli status <rental_id>
-    cathedral-cli terminate <rental_id>
-    cathedral-cli rentals                         # list all my rentals
+    cathedral-cli status                 # overall subnet state
+    cathedral-cli miner <uid>            # one miner's validator-side state
+    cathedral-cli miners                 # all registered-with-us miners
+    cathedral-cli validators             # 14 permit holders on SN39
 
 Env:
-    CATHEDRAL_API             default https://api.polaris.computer
-    CATHEDRAL_API_KEY         optional; sent as X-Polaris-API-Key
+    CATHEDRAL_API    default https://api.polaris.computer
+                     (validator APIs are proxied through polaris infra; this
+                     is the read surface the site uses, safe + public)
 """
 from __future__ import annotations
 
@@ -24,24 +24,18 @@ import os
 import sys
 import urllib.request
 import urllib.error
-from pathlib import Path
 
 DEFAULT_API = os.getenv("CATHEDRAL_API", "https://api.polaris.computer")
-API_KEY = os.getenv("CATHEDRAL_API_KEY", "")
 
 
-def _req(method: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+def _get(path: str) -> tuple[int, dict]:
     url = f"{DEFAULT_API}{path}"
-    data = json.dumps(body).encode() if body is not None else None
-    req = urllib.request.Request(url, data=data, method=method)
-    req.add_header("Content-Type", "application/json")
-    # Cloudflare bot-challenges the default Python-urllib UA and returns 403
-    # before the request reaches our Railway backend. Any real UA avoids that.
-    req.add_header("User-Agent", "cathedral-cli/0.1")
-    if API_KEY:
-        req.add_header("X-Polaris-API-Key", API_KEY)
+    req = urllib.request.Request(url)
+    # Cloudflare bot-challenges the default Python-urllib UA. Any real UA
+    # bypasses the challenge and reaches our backend.
+    req.add_header("User-Agent", "cathedral-cli/0.2")
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=15) as resp:
             return resp.status, json.loads(resp.read() or b"{}")
     except urllib.error.HTTPError as e:
         try:
@@ -50,159 +44,134 @@ def _req(method: str, path: str, body: dict | None = None) -> tuple[int, dict]:
             return e.code, {"error": str(e)}
 
 
-def _fmt_price(cents: int | None) -> str:
-    if cents is None:
-        return "-"
-    return f"${cents/100:.2f}/hr"
+def _fmt_stake(x: float | None) -> str:
+    if x is None:
+        return "—"
+    if x >= 1000:
+        return f"{x:,.0f}"
+    if x >= 10:
+        return f"{x:.1f}"
+    return f"{x:.2f}"
 
 
-def cmd_list(args: argparse.Namespace) -> int:
-    qs = []
-    if args.category:
-        qs.append(f"category={args.category}")
-    if args.min_memory_gb is not None:
-        qs.append(f"min_memory_gb={args.min_memory_gb}")
-    if args.max_price_cents is not None:
-        qs.append(f"max_price_cents={args.max_price_cents}")
-    path = "/api/v1/cathedral/machines"
-    if qs:
-        path += "?" + "&".join(qs)
-    status, body = _req("GET", path)
+def cmd_status(_args: argparse.Namespace) -> int:
+    status, chain = _get("/api/substrate/state")
     if status >= 400:
-        print(f"error: {status} {body}", file=sys.stderr)
+        print(f"error: {status} {chain}", file=sys.stderr)
         return 1
+    summary = chain.get("summary") or {}
 
-    machines = body.get("machines", [])
-    if not machines:
-        print("(no machines match your filters)")
-        return 0
+    status2, reg = _get("/api/substrate/validator/registry")
+    reg_data = reg.get("data") or {} if status2 < 400 else {}
 
-    if args.json:
-        print(json.dumps(machines, indent=2))
-        return 0
-
-    # Human table
-    cols = ("node_id", "category", "count", "mem(gb)", "location", "price", "net_down")
-    widths = (12, 28, 6, 8, 22, 10, 10)
-    print(" ".join(c.ljust(w) for c, w in zip(cols, widths)))
-    print(" ".join("-" * w for w in widths))
-    for m in machines:
-        row = (
-            str(m.get("node_id") or "")[:11],
-            str(m.get("category") or "")[:27],
-            str(m.get("gpu_count") if not m.get("is_cpu_only") else m.get("cpu_cores") or ""),
-            str(m.get("memory_gb") or ""),
-            str(m.get("location") or "")[:21],
-            _fmt_price(m.get("hourly_rate_cents")),
-            f"{m.get('network_mbps_down') or 0:.0f}mbps",
-        )
-        print(" ".join(v.ljust(w) for v, w in zip(row, widths)))
-    print(f"\n{body.get('total', 0)} machine(s)")
+    print(f"Subnet:           SN39 · finney")
+    print(f"Block:            {summary.get('block', '—'):,}")
+    print(f"Our validator:    uid 123 ({(chain.get('miners') or [{}])[0].get('status', '—').lower() if False else 'see below'})")
+    us = next((m for m in chain.get("miners", []) if m.get("uid") == 123), None)
+    if us:
+        print(f"  status:         {str(us.get('status','')).lower()}")
+        print(f"  stake:          {_fmt_stake(us.get('stake'))}α")
+        print(f"  incentive:      {_fmt_stake(us.get('incentive'))}")
+    print()
+    print(f"Miners declared:  {summary.get('active_miners', '—')} of {summary.get('total_miners', '—')}")
+    print(f"Registered:       {reg_data.get('miners_with_nodes', 0)}")
+    print(f"Nodes total:      {reg_data.get('nodes_registered', 0)}")
+    print(f"Verified nodes:   {reg_data.get('nodes_verified', 0)}")
     return 0
 
 
-def cmd_show(args: argparse.Namespace) -> int:
-    status, body = _req("GET", f"/api/v1/cathedral/machines/{args.node_id}")
+def cmd_miners(_args: argparse.Namespace) -> int:
+    status, reg = _get("/api/substrate/validator/registry")
     if status >= 400:
-        print(f"error: {status} {body}", file=sys.stderr)
+        print(f"error: {status} {reg}", file=sys.stderr)
         return 1
-    print(json.dumps(body, indent=2))
+    miners = ((reg.get("data") or {}).get("miners")) or []
+    if not miners:
+        print("(no miners registered with our validator yet)")
+        return 0
+    # Fetch chain state for hotkey lookups
+    _, chain = _get("/api/substrate/state")
+    by_uid = {m["uid"]: m for m in (chain.get("miners") or []) if "uid" in m}
+
+    widths = (6, 24, 12, 12)
+    print("uid".ljust(widths[0]), "hotkey".ljust(widths[1]), "status".ljust(widths[2]), "bid".ljust(widths[3]))
+    print("-" * sum(widths))
+    order = {"verified": 0, "online": 1, "offline": 2}
+    miners.sort(key=lambda m: (order.get(m.get("status"), 9), m.get("uid", 0)))
+    for m in miners:
+        chain_row = by_uid.get(m["uid"], {})
+        hotkey = chain_row.get("hotkey", "")
+        abbrev = (hotkey[:6] + "…" + hotkey[-4:]) if len(hotkey) > 12 else hotkey
+        bid = "active" if m.get("bid_active") else "inactive"
+        print(str(m["uid"]).ljust(widths[0]), abbrev.ljust(widths[1]), str(m.get("status","")).ljust(widths[2]), bid.ljust(widths[3]))
     return 0
 
 
-def cmd_rent(args: argparse.Namespace) -> int:
-    # Read public key from file or inline
-    key_arg = args.ssh_key
-    if key_arg and Path(key_arg).is_file():
-        ssh_pub = Path(key_arg).read_text().strip()
+def cmd_miner(args: argparse.Namespace) -> int:
+    uid = args.uid
+    status, reg = _get("/api/substrate/validator/registry")
+    if status >= 400:
+        print(f"error: {status} {reg}", file=sys.stderr)
+        return 1
+    miners = ((reg.get("data") or {}).get("miners")) or []
+    m = next((x for x in miners if x.get("uid") == uid), None)
+
+    _, chain = _get("/api/substrate/state")
+    chain_row = next((x for x in (chain.get("miners") or []) if x.get("uid") == uid), None)
+
+    print(f"UID:              {uid}")
+    if chain_row:
+        print(f"Hotkey:           {chain_row.get('hotkey', '—')}")
+        print(f"Chain status:     {str(chain_row.get('status','')).lower()}")
+        print(f"Chain axon:       {chain_row.get('ip', '—')}:{chain_row.get('port', '—')}")
+        print(f"Stake:            {_fmt_stake(chain_row.get('stake'))}α")
     else:
-        ssh_pub = key_arg.strip() if key_arg else ""
-    if not ssh_pub.startswith("ssh-"):
-        print("error: --ssh-key must be a path to a public key or an inline key starting with 'ssh-'", file=sys.stderr)
-        return 2
-
-    payload = {
-        "gpu_category": args.category,
-        "gpu_count": args.gpu_count,
-        "max_hourly_rate_cents": args.max_cents,
-        "ssh_public_key": ssh_pub,
-        "container_image": args.image,
-        "command": ["sleep", "infinity"] if not args.command else args.command,
-    }
-    if args.min_memory_gb is not None:
-        payload["min_memory_gb"] = args.min_memory_gb
-
-    status, body = _req("POST", "/api/v1/cathedral/rentals", payload)
-    if status >= 400:
-        print(f"error: {status} {body}", file=sys.stderr)
-        return 1
-    print(json.dumps(body, indent=2))
+        print("Chain status:     not on chain")
+    print()
+    if m:
+        print(f"Validator status: {m.get('status')}")
+        print(f"Bid active:       {bool(m.get('bid_active'))}")
+        print(f"Active rental:    {bool(m.get('has_rental'))}")
+    else:
+        print("Validator status: not registered with our validator")
     return 0
 
 
-def cmd_status(args: argparse.Namespace) -> int:
-    status, body = _req("GET", f"/api/v1/cathedral/rentals/{args.rental_id}")
+def cmd_validators(_args: argparse.Namespace) -> int:
+    status, chain = _get("/api/substrate/state")
     if status >= 400:
-        print(f"error: {status} {body}", file=sys.stderr)
+        print(f"error: {status} {chain}", file=sys.stderr)
         return 1
-    print(json.dumps(body, indent=2))
-    return 0
-
-
-def cmd_terminate(args: argparse.Namespace) -> int:
-    status, body = _req("DELETE", f"/api/v1/cathedral/rentals/{args.rental_id}")
-    if status >= 400:
-        print(f"error: {status} {body}", file=sys.stderr)
-        return 1
-    print(json.dumps(body, indent=2))
-    return 0
-
-
-def cmd_rentals(_args: argparse.Namespace) -> int:
-    status, body = _req("GET", "/api/v1/cathedral/rentals")
-    if status >= 400:
-        print(f"error: {status} {body}", file=sys.stderr)
-        return 1
-    print(json.dumps(body, indent=2))
+    miners = chain.get("miners") or []
+    ranked = sorted(miners, key=lambda m: m.get("stake", 0) or 0, reverse=True)[:14]
+    print(f"{'rank':<6}{'uid':<6}{'hotkey':<24}{'stake':>12}")
+    print("-" * 48)
+    for i, m in enumerate(ranked, 1):
+        hk = m.get("hotkey", "")
+        abbrev = (hk[:6] + "…" + hk[-4:]) if len(hk) > 12 else hk
+        print(f"{i:<6}{m.get('uid',''):<6}{abbrev:<24}{_fmt_stake(m.get('stake')):>12}α")
     return 0
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(prog="cathedral-cli")
+    parser = argparse.ArgumentParser(
+        prog="cathedral-cli",
+        description="Operator tooling for Cathedral (Bittensor SN39). For compute rental / agent deploy, use polaris-cli.",
+    )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    p_list = sub.add_parser("list", help="list available machines")
-    p_list.add_argument("--category", help="GPU category filter (e.g. RTX_5090)")
-    p_list.add_argument("--min-memory-gb", type=int, dest="min_memory_gb")
-    p_list.add_argument("--max-price-cents", type=int, dest="max_price_cents")
-    p_list.add_argument("--json", action="store_true")
-    p_list.set_defaults(func=cmd_list)
+    p_status = sub.add_parser("status", help="subnet state overview")
+    p_status.set_defaults(func=cmd_status)
 
-    p_show = sub.add_parser("show", help="show a single machine")
-    p_show.add_argument("node_id")
-    p_show.set_defaults(func=cmd_show)
+    p_miners = sub.add_parser("miners", help="list miners registered with our validator")
+    p_miners.set_defaults(func=cmd_miners)
 
-    p_rent = sub.add_parser("rent", help="start a rental")
-    p_rent.add_argument("--category", required=True)
-    p_rent.add_argument("--gpu-count", type=int, default=1, dest="gpu_count")
-    p_rent.add_argument("--max-cents", type=int, required=True, dest="max_cents")
-    p_rent.add_argument("--ssh-key", required=True, dest="ssh_key",
-                        help="path to public key, or inline 'ssh-ed25519 ...' string")
-    p_rent.add_argument("--image", default="ubuntu:24.04")
-    p_rent.add_argument("--command", nargs="*")
-    p_rent.add_argument("--min-memory-gb", type=int, dest="min_memory_gb")
-    p_rent.set_defaults(func=cmd_rent)
+    p_miner = sub.add_parser("miner", help="one miner's state on cathedral")
+    p_miner.add_argument("uid", type=int)
+    p_miner.set_defaults(func=cmd_miner)
 
-    p_st = sub.add_parser("status", help="rental status")
-    p_st.add_argument("rental_id")
-    p_st.set_defaults(func=cmd_status)
-
-    p_term = sub.add_parser("terminate", help="terminate a rental")
-    p_term.add_argument("rental_id")
-    p_term.set_defaults(func=cmd_terminate)
-
-    p_ren = sub.add_parser("rentals", help="list my rentals")
-    p_ren.set_defaults(func=cmd_rentals)
+    p_val = sub.add_parser("validators", help="top 14 permit holders on SN39")
+    p_val.set_defaults(func=cmd_validators)
 
     args = parser.parse_args()
     return args.func(args)


### PR DESCRIPTION
Cathedral = subnet/protocol. Polaris = product/platform. The earlier CLI leaked user-facing rental commands into cathedral-cli; moving those out so the tool focuses on operator concerns (status, miners, validators). Rent/deploy/run surfaces belong under polaris-cli on polariscomputer.