### PR TITLE
fix(validator): Lightweight success graduates node to verified status

### DIFF
--- a/crates/basilica-validator/src/miner_prover/verification.rs
+++ b/crates/basilica-validator/src/miner_prover/verification.rs
@@ -557,14 +557,19 @@ impl VerificationEngine {
             (true, ValidationType::Full) => "online".to_string(),
             (true, ValidationType::Lightweight) => {
                 if is_rented {
+                    // Active rentals keep "online" — flipping to "verified"
+                    // mid-rental confuses downstream consumers that assume
+                    // "verified" implies idle-ready.
                     "online".to_string()
                 } else {
-                    self.persistence
-                        .get_node_status(&verification_log.node_id, &miner_id)
-                        .await
-                        .ok()
-                        .flatten()
-                        .unwrap_or_else(|| "verified".to_string())
+                    // Non-rented Lightweight success graduates the node.
+                    // Full sets "online" (confirms presence + attestation).
+                    // Lightweight re-confirms without the full probe — the
+                    // correct next state is "verified". Previously this
+                    // path looked up the current status and fell back only
+                    // on None, which meant existing online rows stayed
+                    // online forever (verified count stuck at 0).
+                    "verified".to_string()
                 }
             }
         };


### PR DESCRIPTION
Bug: nodes never reached status='verified' because Lightweight only set 'verified' as a None fallback after reading the current DB status — which returned Some('online') and short-circuited. Every successful Lightweight re-wrote 'online' back, so the funnel's verified count was permanently 0 even though two real miners passed all checks.