### PR TITLE
docs: add CREDITS.md acknowledging the Basilica team

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,57 @@
+# Credits
+
+Cathedral runs on an engine we did not build. The story it tells is ours;
+the engineering that makes it possible is theirs.
+
+## The engine
+
+Cathedral's technical foundation is [Basilica](https://github.com/one-covenant/basilica),
+a Bittensor-native compute verification subnet built by the **Covenant AI** team
+between 2025 and 2026. Basilica is the part that inspects the metal: SSH-based
+hardware attestation, a validator that actually verifies GPUs, and a miner
+framework home operators can run. That engineering is what makes any of this
+possible.
+
+Upstream continues to ship. Cathedral is a fork of that codebase. Without it
+there is no cathedral, only an idea.
+
+## Engineering
+
+| Name                   | Role                                                          |
+|------------------------|---------------------------------------------------------------|
+| Evan Pappas (epappas)  | Lead engineer, Basilica                                       |
+| itzlambda              | Lead engineer, Basilica                                       |
+| open-junius            | Foundational verification work, Opentensor Foundation         |
+| Covenant AI            | Original team                                                 |
+
+## What Cathedral is
+
+Cathedral is not Basilica with a new name. It is a distinct project with its
+own thesis, audience, vocabulary, and posture. The engine verifies hardware;
+Cathedral is what we are building with it.
+
+Distinct to Cathedral:
+
+- **The thesis.** Home-ownable compute as a commons. A subnet built in public,
+  at the pace of trust, for whoever shows up with a stone.
+- **The brand.** Cathedral. The name, the rose-window mark, the medieval-trades
+  vocabulary — masons, apprentices, patrons, clerks, the yard.
+- **The frame.** Mining reframed as laying stone. Validator as the master mason.
+  Learning as apprenticeship. Emissions as a ledger kept in public.
+- **The audience.** A go-to-market pointed at home operators, student hardware,
+  global-south mason cohorts. Afrotensor is cathedral's bootcamp.
+- **The editorial surface.** [cathedral.computer](https://cathedral.computer) —
+  the three-act roadmap, the honest-numbers register, the public log stream,
+  the /masons register, the /ledger pipeline, the /afrotensor curriculum.
+- **The operating decisions.** What gets built, in which order, for whom.
+  The business model, worked out one stone at a time.
+
+## License
+
+MIT, inherited from Basilica. The upstream copyright notice
+(`© 2025 tplr.ai`) is preserved in [LICENSE](LICENSE) per the terms of the
+license. Modifications made in this fork are © 2026 bigailabs, offered
+under the same MIT terms.
+
+- Upstream: [github.com/one-covenant/basilica](https://github.com/one-covenant/basilica)
+- This fork: [github.com/bigailabs/cathedral](https://github.com/bigailabs/cathedral)

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 # The MIT License (MIT)
 # © 2025 tplr.ai
+# Portions © 2026 bigailabs (cathedral fork modifications)
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the "Software"), to deal in the Software without restriction, including without limitation

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It is recommended not to stake to SN39 at this time. See [docs/policy.md](docs/p
 
 A compute subnet on Bittensor. Miners — the masons — bring hardware and raise it into the wall. Validators — the master masons — inspect each stone: is it real, does it hold, is it the GPU (or CPU) it claims to be. Applications consume the compute that emerges from the cathedral.
 
-Forked from [Basilica](https://github.com/one-covenant/basilica) under MIT. The code survived. Cathedral carries it forward on home-ownable hardware instead of data-center SKUs.
+Forked from [Basilica](https://github.com/one-covenant/basilica) under MIT. The code survived. Cathedral carries it forward on home-ownable hardware instead of data-center SKUs. See [CREDITS.md](CREDITS.md) for the full acknowledgement.
 
 ## Lay a stone
 
@@ -92,10 +92,12 @@ Both are in the same group, but the concerns are clean. `cathedral-cli` does min
 
 ## Origins
 
-Forked from [one-covenant/basilica](https://github.com/one-covenant/basilica) under MIT. The original code was written by the Covenant team between 2025 and 2026. Their work made this possible.
+Forked from [one-covenant/basilica](https://github.com/one-covenant/basilica) under MIT. The original code was written by the **Covenant AI** team between 2025 and 2026 — Evan Pappas (epappas), itzlambda, and open-junius at the Opentensor Foundation. Their work made this possible.
+
+Full acknowledgement and what's distinct to cathedral: [CREDITS.md](CREDITS.md).
 
 Operated by [polaris.computer](https://polaris.computer).
 
 ## License
 
-MIT
+MIT. Upstream copyright (`© 2025 tplr.ai`) preserved in [LICENSE](LICENSE). Modifications in this fork are © 2026 bigailabs, offered under the same terms.


### PR DESCRIPTION
Cathedral runs on an engine we did not build. The story it tells is ours; the engineering that makes it possible is theirs. This PR makes that acknowledgement first-class in the repo.

## Changes

- **New \`CREDITS.md\`** at repo root, three sections:
  - The engine — what Basilica provides and why it matters
  - Engineering — named credits for Evan Pappas (epappas), itzlambda, open-junius (Opentensor Foundation), and Covenant AI
  - What Cathedral is — explicit list of what's distinct to this project (thesis, brand, frame, audience, editorial surface, operating decisions)
- **README.md:** fork references now point to \`CREDITS.md\`; Origins section names the three engineers; License section notes modifications are © 2026 bigailabs under MIT
- **LICENSE:** upstream \`© 2025 tplr.ai\` preserved (required by MIT); added \`Portions © 2026 bigailabs (cathedral fork modifications)\` per standard MIT fork practice

## Why three places, not one
- \`CREDITS.md\` is where contributors browsing GitHub look
- README links make it discoverable without clicking into CREDITS
- LICENSE portion line is the legally correct form for MIT fork copyright

Mirrors what just landed on the marketing site as \`/origins\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)