### PR TITLE
Add cost-collapse supply starter kit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory contains comprehensive documentation for the Basilica decentraliz
 
 - **[Validator Guide](validator.md)** - Deploy and manage validator nodes for network verification
 - **[Miner Guide](miner.md)** - Set up miners to orchestrate GPU node access via SSH
+- **[Cost-Collapse Supply Kit](cost-collapse/README.md)** - Recruit and preflight miner submissions for Polaris workflow optimization assets
 
 ### Operations
 

--- a/docs/cost-collapse/README.md
+++ b/docs/cost-collapse/README.md
@@ -75,7 +75,8 @@ Do not open rewards until these fields are frozen:
 - baseline cost and latency window
 - minimum quality-retention threshold
 - Polaris deployment link format
-- usage attribution event schema
+- Polaris proof API path: `/api/cost-collapse/proof/{run_id}`
+- Polaris attribution API path: `/api/cost-collapse/attribution/{optimization_artifact_id}`
 - reward tiers and decay rule
 
 Until those exist, this package is a private dry-run kit for credible miners and builders.

--- a/docs/cost-collapse/README.md
+++ b/docs/cost-collapse/README.md
@@ -1,0 +1,81 @@
+# Cathedral Cost-Collapse Supply Kit
+
+Cathedral rewards reusable optimization assets that make Polaris-hosted agent workflows cheaper, faster, or better while preserving the target outcome.
+
+This kit is the supply-side launch package for the first cost-collapse sprint.
+
+## First Competition
+
+The first competition is:
+
+> Bittensor Subnet Analyst Compression
+
+The target workflow is an expensive Polaris-hosted subnet analyst agent. Miners produce the cheapest validated intervention that preserves evidence quality, citation quality, and risk detection.
+
+Allowed interventions include:
+
+- model distillation
+- LoRA or adapter
+- router
+- prompt-compression recipe
+- cheaper judge
+- cached tool-plan policy
+- retrieval pack
+- trace dataset paired with a deployable eval harness
+- failure diagnosis that removes unnecessary expensive work
+
+The winning artifact is not necessarily a model. It is the cheapest validated intervention that keeps the outcome useful.
+
+## Eligibility Rule
+
+Every eligible submission must include:
+
+- reproducible job specification
+- held-out task eval result
+- cost, latency, and task-quality report
+- one-click Polaris deployment link
+- usage attribution path
+
+Standalone HuggingFace models, public-benchmark-only improvements, datasets without deployable harnesses, and miner self-deploy usage are not eligible for rewards.
+
+## Kit Map
+
+- `bittensor-subnet-analyst-compression/miner-brief.md`
+- `bittensor-subnet-analyst-compression/public-call.md`
+- `bittensor-subnet-analyst-compression/recruiting-dm.md`
+- `bittensor-subnet-analyst-compression/scoring-and-disqualification.md`
+- `bittensor-subnet-analyst-compression/demand-handoff-template.md`
+- `starter-kit/job-spec.template.yaml`
+- `starter-kit/submission-manifest.schema.json`
+- `starter-kit/submission-manifest.example.json`
+- `starter-kit/cost-latency-quality-report.template.md`
+- `starter-kit/preflight-eligibility-checklist.md`
+- `starter-kit/invalid-submissions.md`
+
+## Local Preflight
+
+Run the checker before sending any submission to a validator or demand-side deployment test:
+
+```bash
+python3 scripts/cost-collapse/preflight.py \
+  docs/cost-collapse/starter-kit/submission-manifest.example.json \
+  --root docs/cost-collapse/starter-kit
+```
+
+The preflight checker validates the manifest shape, referenced files, required deployment and attribution links, cost and latency deltas, minimum quality retention, and disqualifier flags.
+
+Preflight passing does not mean the artifact wins. It only means the artifact is eligible for scoring.
+
+## Launch Gate
+
+Do not open rewards until these fields are frozen:
+
+- baseline Polaris workflow id
+- hidden or rotating held-out eval id
+- baseline cost and latency window
+- minimum quality-retention threshold
+- Polaris deployment link format
+- usage attribution event schema
+- reward tiers and decay rule
+
+Until those exist, this package is a private dry-run kit for credible miners and builders.

--- a/docs/cost-collapse/bittensor-subnet-analyst-compression/demand-handoff-template.md
+++ b/docs/cost-collapse/bittensor-subnet-analyst-compression/demand-handoff-template.md
@@ -1,0 +1,25 @@
+# Demand Handoff Template
+
+Use this table when a supply-side artifact passes preflight and is ready for demand validation.
+
+| Field | Value |
+|---|---|
+| artifact id |  |
+| creator |  |
+| intervention type |  |
+| baseline workflow id |  |
+| optimized deployment link |  |
+| attribution path |  |
+| held-out eval id |  |
+| quality retention |  |
+| baseline credits per task |  |
+| optimized credits per task |  |
+| baseline latency seconds |  |
+| optimized latency seconds |  |
+| known quality tradeoff |  |
+| failure mode to watch |  |
+| target external users |  |
+| demand test owner |  |
+| accepted for public launch | no |
+
+Demand-side validation must record whether the deployer was first-party, creator-owned, founder-assisted, free-credit, paid-credit, or unassisted external usage.

--- a/docs/cost-collapse/bittensor-subnet-analyst-compression/miner-brief.md
+++ b/docs/cost-collapse/bittensor-subnet-analyst-compression/miner-brief.md
@@ -1,0 +1,82 @@
+# Miner Brief: Bittensor Subnet Analyst Compression
+
+## Competition
+
+Make a Polaris-hosted Bittensor subnet analyst workflow cheaper, faster, or better without losing the useful output.
+
+Prompt:
+
+> This Polaris-hosted analyst costs X credits and takes Y seconds to answer Z. Find the smallest intervention that preserves the outcome for less.
+
+## Baseline Workflow
+
+The baseline analyst answers subnet research questions using Bittensor chat evidence, repo metadata, chain state, and public docs. A useful answer must cite evidence, separate demand from supply, flag reliability risk, and state what would change the conclusion.
+
+Baseline fields to freeze before public launch:
+
+- Polaris workflow id
+- baseline trace window
+- baseline median credits per task
+- baseline median latency
+- baseline failure rate
+- held-out task set id
+
+## Target Task
+
+Answer hidden subnet-analysis prompts such as:
+
+- Which subnet looks most useful for a new agent workflow, and why?
+- Where does a subnet show demand instead of induced supply?
+- What reliability or incentive failure mode is most likely?
+- Which evidence is stale, missing, or contradicted?
+
+## Allowed Interventions
+
+Miners may submit:
+
+- distilled small analyst model
+- LoRA or adapter
+- routing policy that calls the expensive model only on hard cases
+- prompt-compression recipe
+- evidence retrieval pack
+- cheaper subnet-risk judge
+- cached tool-plan policy
+- trace dataset paired with a deployable eval harness
+- failure diagnosis that removes unnecessary expensive work
+
+## Required Output
+
+Every submission must include:
+
+- `job-spec.yaml`
+- `submission-manifest.json`
+- `cost-latency-quality-report.md`
+- held-out eval result artifact
+- deployed optimized artifact or deployable harness
+- one-click Polaris deployment link
+- usage attribution path
+
+## Reward Tiers
+
+| Tier | What it means | Gate |
+|---|---|---|
+| Eligible | Artifact can be scored | Preflight passes and deployment link works |
+| Quality bonus | Artifact preserves useful output | Hidden eval meets minimum retention |
+| Cost bonus | Artifact reduces cost or latency | Reported delta verifies under Cathedral control |
+| Usage bonus | Other users deploy it | Attributed external usage and credit spend |
+| Maintenance | Artifact keeps earning | It remains deployable and does not drift |
+
+## Disqualifiers
+
+- model-only artifact
+- public benchmark only
+- missing Polaris deploy link
+- missing usage attribution path
+- eval result not reproducible from the job spec
+- quality loss hidden by cost-only reporting
+- miner self-deploy counted as demand
+- creator-owned, refunded, or abuse-flagged usage counted as usage bonus
+
+## Handoff To Demand Side
+
+Accepted artifacts move to demand validation only after eligibility passes. Demand validation tests whether a real external user deploys it, understands the tradeoff, and would repeat usage.

--- a/docs/cost-collapse/bittensor-subnet-analyst-compression/public-call.md
+++ b/docs/cost-collapse/bittensor-subnet-analyst-compression/public-call.md
@@ -1,0 +1,25 @@
+# Public Call: Make Subnet Analysis Cheaper
+
+Cathedral is opening a private dry run for Bittensor Subnet Analyst Compression.
+
+The job is simple:
+
+> Take an expensive Polaris-hosted subnet analyst workflow and find the cheapest validated intervention that preserves the answer quality.
+
+We are not looking for a standalone model leaderboard.
+
+Eligible submissions must include:
+
+- reproducible job spec
+- held-out eval result
+- cost, latency, and task-quality report
+- one-click Polaris deployment link
+- usage attribution path
+
+You can win with a smaller model, LoRA, router, prompt-compression recipe, evidence pack, cheaper judge, tool-plan cache, or a deployable eval harness. The artifact has to run on Polaris and stay useful when other people deploy it.
+
+The first sprint is pre-launch. We are recruiting a small group of miners and builders who can run the starter kit, produce a real optimization asset, and help freeze the scoring path before public rewards.
+
+If your submission only improves a public benchmark, only uploads a model, or only works on your own deployment, it is not eligible.
+
+Bring the cheapest fix that still works.

--- a/docs/cost-collapse/bittensor-subnet-analyst-compression/recruiting-dm.md
+++ b/docs/cost-collapse/bittensor-subnet-analyst-compression/recruiting-dm.md
@@ -1,0 +1,13 @@
+# Recruiting DM
+
+Hey, we are opening a small Cathedral dry run for Bittensor Subnet Analyst Compression.
+
+The task is to make a Polaris-hosted subnet analyst cheaper or faster without losing citation quality, demand analysis, or risk detection.
+
+This is not a model-only leaderboard. Eligible submissions need a reproducible job spec, held-out eval result, cost/latency/quality report, Polaris deployment link, and usage attribution path.
+
+You can win through a small model, LoRA, router, prompt compression, retrieval pack, cheaper judge, tool-plan cache, or deployable eval harness.
+
+The question is: can you produce the cheapest validated fix that other people can deploy on Polaris?
+
+If yes, I can send the starter kit and preflight checker.

--- a/docs/cost-collapse/bittensor-subnet-analyst-compression/scoring-and-disqualification.md
+++ b/docs/cost-collapse/bittensor-subnet-analyst-compression/scoring-and-disqualification.md
@@ -1,0 +1,47 @@
+# Scoring And Disqualification
+
+## Scoring Inputs
+
+| Input | Description | Required |
+|---|---|---|
+| outcome retention | Held-out task quality vs baseline | Yes |
+| citation correctness | Evidence is cited and not hallucinated | Yes |
+| demand reasoning | Separates customer demand from induced supply | Yes |
+| risk detection | Flags reliability, incentive, and attribution risk | Yes |
+| cost reduction | Credits per task vs baseline | Yes |
+| latency reduction | Seconds per task vs baseline | Yes |
+| failure rate | Failed or unusable outputs vs baseline | Yes |
+| deployment reliability | Polaris deployment works repeatedly | Yes |
+| external usage | Non-creator deploys and credit spend | Bonus |
+
+## Suggested Score Shape
+
+Eligibility is binary. If eligibility fails, no score is published.
+
+For eligible submissions:
+
+- quality gate: minimum 0.85 outcome retention
+- citation gate: no fabricated evidence in held-out samples
+- cost score: baseline credits per task divided by optimized credits per task
+- latency score: baseline seconds divided by optimized seconds
+- robustness penalty: hidden-eval failure rate and obvious gaming attempts
+- usage bonus: external attributed paid usage after deployment
+
+## Disqualification Rules
+
+Disqualify a submission if it:
+
+- cannot be reproduced from the job spec
+- lacks a working Polaris deployment link
+- lacks a usage attribution path
+- submits only a model card, dataset, notebook, or public benchmark score
+- hides material quality loss
+- requires manual founder setup
+- counts miner-owned usage as external demand
+- uses refunded, platform-owned, or abuse-flagged credits for usage bonus
+- leaks private eval tasks or trains directly on hidden labels
+- breaks after the first run and is not repaired inside the maintenance window
+
+## Maintenance Rule
+
+Passing once does not create permanent emissions. Base rewards decay unless the artifact remains deployable, passes maintenance checks, or earns real attributed usage.

--- a/docs/cost-collapse/starter-kit/cost-latency-quality-report.template.md
+++ b/docs/cost-collapse/starter-kit/cost-latency-quality-report.template.md
@@ -1,0 +1,53 @@
+# Cost, Latency, And Task-Quality Report
+
+## Artifact
+
+- artifact id:
+- artifact type:
+- creator:
+- competition id: bittensor-subnet-analyst-compression
+
+## Baseline
+
+- Polaris workflow id:
+- trace window:
+- median credits per task:
+- median latency seconds:
+- failure rate:
+- baseline deployment link:
+
+## Optimized Artifact
+
+- one-click Polaris deployment link:
+- attribution URL:
+- health URL:
+- ready URL:
+- runtime profile:
+
+## Eval
+
+- held-out eval id:
+- eval command:
+- number of tasks:
+- outcome retention:
+- citation correctness:
+- risk-detection score:
+- demand-vs-supply score:
+
+## Delta
+
+| Metric | Baseline | Optimized | Delta |
+|---|---:|---:|---:|
+| credits per task |  |  |  |
+| latency seconds |  |  |  |
+| failure rate |  |  |  |
+| outcome quality |  |  |  |
+| citation correctness |  |  |  |
+
+## Known Tradeoffs
+
+Describe where the artifact is worse than baseline and when Polaris should route back to the expensive workflow.
+
+## Maintenance Plan
+
+Describe what will be monitored, what breaks eligibility, and who repairs drift.

--- a/docs/cost-collapse/starter-kit/invalid-submissions.md
+++ b/docs/cost-collapse/starter-kit/invalid-submissions.md
@@ -1,0 +1,51 @@
+# Invalid Submission Examples
+
+## Model-Only Upload
+
+Invalid:
+
+- uploads a HuggingFace model
+- cites a public benchmark
+- has no Polaris deployment link
+- has no usage attribution path
+
+Why it fails:
+
+Cathedral optimizes Polaris-hosted workflows, not standalone model leaderboards.
+
+## Dataset-Only Upload
+
+Invalid:
+
+- uploads traces or labels
+- has no deployable evaluator
+- has no optimized artifact
+- cannot run a held-out eval from the job spec
+
+Why it fails:
+
+Datasets are only useful when paired with a deployable evaluator, harness, or optimized artifact.
+
+## Cost-Only Claim
+
+Invalid:
+
+- reduces credits per task
+- hides quality loss
+- does not report citation correctness or failure rate
+
+Why it fails:
+
+Cost collapse must preserve the target outcome. Cheap wrong answers are not eligible.
+
+## Self-Deploy Demand
+
+Invalid:
+
+- creator deploys the artifact repeatedly
+- credits are free, refunded, platform-owned, or abuse-flagged
+- usage is presented as downstream demand
+
+Why it fails:
+
+Usage bonuses require external attributed usage. Creator-owned usage is learning, not demand.

--- a/docs/cost-collapse/starter-kit/job-spec.template.yaml
+++ b/docs/cost-collapse/starter-kit/job-spec.template.yaml
@@ -1,0 +1,39 @@
+schema_version: cathedral.cost_collapse.job_spec.v1
+competition_id: bittensor-subnet-analyst-compression
+artifact_id: replace-with-unique-artifact-id
+creator:
+  name: replace-with-name
+  contact: replace-with-contact
+  bittensor_hotkey: replace-with-hotkey
+baseline:
+  workflow_id: polaris-workflow-subnet-analyst-v0
+  trace_window: replace-with-trace-window
+  median_credits_per_task: 0.0
+  median_latency_seconds: 0.0
+  failure_rate: 0.0
+target:
+  task: Answer held-out Bittensor subnet-analysis questions.
+  minimum_quality_retention: 0.85
+  required_capabilities:
+    - citation_correctness
+    - demand_vs_supply_reasoning
+    - risk_detection
+    - stale_evidence_flagging
+intervention:
+  type: prompt_compression
+  summary: Replace with the smallest validated intervention.
+  training_or_build_steps:
+    - Replace with reproducible command or script.
+runtime:
+  polaris_profile: cpu-smoke
+  container_image: replace-with-image-digest
+  app_port: 8080
+  health_path: /health
+  ready_path: /ready
+  required_secrets: []
+eval:
+  held_out_eval_id: replace-with-held-out-eval-id
+  command: replace-with-eval-command
+deployment:
+  one_click_polaris_url: https://polaris.computer/deploy/example
+  attribution_url: https://polaris.computer/attribution/example

--- a/docs/cost-collapse/starter-kit/job-spec.template.yaml
+++ b/docs/cost-collapse/starter-kit/job-spec.template.yaml
@@ -36,4 +36,4 @@ eval:
   command: replace-with-eval-command
 deployment:
   one_click_polaris_url: https://polaris.computer/deploy/example
-  attribution_url: https://polaris.computer/attribution/example
+  attribution_url: https://polaris.computer/api/cost-collapse/attribution/example

--- a/docs/cost-collapse/starter-kit/preflight-eligibility-checklist.md
+++ b/docs/cost-collapse/starter-kit/preflight-eligibility-checklist.md
@@ -1,0 +1,39 @@
+# Preflight Eligibility Checklist
+
+Use this checklist before a submission enters Cathedral scoring.
+
+## Required Files
+
+- [ ] `job-spec.yaml` exists and describes how to reproduce the artifact.
+- [ ] `submission-manifest.json` follows the v1 schema.
+- [ ] `cost-latency-quality-report.md` includes baseline and optimized metrics.
+- [ ] held-out eval result file exists.
+- [ ] artifact or deployable harness exists.
+
+## Deployment
+
+- [ ] one-click Polaris deployment link is present.
+- [ ] health URL is present.
+- [ ] ready URL is present.
+- [ ] usage attribution URL is present.
+- [ ] artifact event name is present.
+
+## Metrics
+
+- [ ] optimized credits per task are lower than baseline credits per task.
+- [ ] optimized latency is lower than baseline latency, or the quality report explains why latency increased.
+- [ ] outcome retention is at least the competition threshold.
+- [ ] citation correctness is reported.
+- [ ] known tradeoffs are disclosed.
+
+## Disqualifiers
+
+- [ ] not model-only
+- [ ] not public-benchmark-only
+- [ ] not dataset-only
+- [ ] reproducible from job spec
+- [ ] does not count self-deploy usage as demand
+
+## Result
+
+Preflight passing means eligible for scoring. It does not mean the artifact wins or deserves emissions.

--- a/docs/cost-collapse/starter-kit/submission-manifest.example.json
+++ b/docs/cost-collapse/starter-kit/submission-manifest.example.json
@@ -38,7 +38,7 @@
     "known_tradeoffs": "May underperform on subnets with no local chat evidence. Routes those to the expensive analyst."
   },
   "usage_attribution": {
-    "attribution_url": "https://polaris.computer/attribution/subnet-analyst-prompt-router-v0",
+    "attribution_url": "https://polaris.computer/api/cost-collapse/attribution/subnet-analyst-prompt-router-v0",
     "artifact_event_name": "cost_collapse_artifact_deployed",
     "exclude_creator_owned_usage": true
   },

--- a/docs/cost-collapse/starter-kit/submission-manifest.example.json
+++ b/docs/cost-collapse/starter-kit/submission-manifest.example.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "cathedral.cost_collapse.submission_manifest.v1",
+  "competition_id": "bittensor-subnet-analyst-compression",
+  "artifact": {
+    "id": "subnet-analyst-prompt-router-v0",
+    "name": "Subnet Analyst Prompt Router v0",
+    "type": "router",
+    "summary": "Routes easy subnet-analysis prompts to a compact prompt and reserves the expensive analyst for hard evidence-heavy cases."
+  },
+  "creator": {
+    "name": "Example Builder",
+    "contact": "builder@example.com",
+    "bittensor_hotkey": "5ExampleHotkeyReplaceMe"
+  },
+  "paths": {
+    "job_spec": "job-spec.template.yaml",
+    "report": "cost-latency-quality-report.template.md",
+    "eval_results": "../../../tests/cost-collapse/fixtures/eval-results.example.json",
+    "artifact": "../../../tests/cost-collapse/fixtures/artifact"
+  },
+  "deployment": {
+    "one_click_polaris_url": "https://polaris.computer/deploy/subnet-analyst-prompt-router-v0",
+    "health_url": "https://proof.polaris.computer/subnet-analyst-prompt-router-v0/health",
+    "ready_url": "https://proof.polaris.computer/subnet-analyst-prompt-router-v0/ready"
+  },
+  "metrics": {
+    "baseline_credits_per_task": 1.0,
+    "optimized_credits_per_task": 0.42,
+    "baseline_latency_seconds": 120.0,
+    "optimized_latency_seconds": 54.0,
+    "baseline_failure_rate": 0.04,
+    "optimized_failure_rate": 0.05
+  },
+  "quality": {
+    "held_out_eval_id": "subnet-analyst-heldout-v0",
+    "outcome_retention": 0.9,
+    "citation_correctness": 0.92,
+    "known_tradeoffs": "May underperform on subnets with no local chat evidence. Routes those to the expensive analyst."
+  },
+  "usage_attribution": {
+    "attribution_url": "https://polaris.computer/attribution/subnet-analyst-prompt-router-v0",
+    "artifact_event_name": "cost_collapse_artifact_deployed",
+    "exclude_creator_owned_usage": true
+  },
+  "disqualifier_attestations": {
+    "not_model_only": true,
+    "not_public_benchmark_only": true,
+    "not_dataset_only": true,
+    "reproducible_from_job_spec": true,
+    "does_not_count_self_deploy_as_demand": true
+  }
+}

--- a/docs/cost-collapse/starter-kit/submission-manifest.schema.json
+++ b/docs/cost-collapse/starter-kit/submission-manifest.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cathedral.computer/schemas/cost-collapse-submission-manifest-v1.json",
+  "title": "Cathedral Cost-Collapse Submission Manifest",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "competition_id",
+    "artifact",
+    "creator",
+    "paths",
+    "deployment",
+    "metrics",
+    "quality",
+    "usage_attribution",
+    "disqualifier_attestations"
+  ],
+  "properties": {
+    "schema_version": { "const": "cathedral.cost_collapse.submission_manifest.v1" },
+    "competition_id": { "const": "bittensor-subnet-analyst-compression" },
+    "artifact": {
+      "type": "object",
+      "required": ["id", "name", "type", "summary"],
+      "properties": {
+        "id": { "type": "string", "minLength": 3 },
+        "name": { "type": "string", "minLength": 3 },
+        "type": {
+          "enum": [
+            "distilled_model",
+            "lora_adapter",
+            "router",
+            "prompt_compression_recipe",
+            "specialized_judge",
+            "cached_tool_plan_policy",
+            "retrieval_pack",
+            "trace_dataset_with_eval_harness",
+            "failure_diagnosis"
+          ]
+        },
+        "summary": { "type": "string", "minLength": 20 }
+      }
+    },
+    "creator": {
+      "type": "object",
+      "required": ["name", "contact", "bittensor_hotkey"],
+      "properties": {
+        "name": { "type": "string" },
+        "contact": { "type": "string" },
+        "bittensor_hotkey": { "type": "string" }
+      }
+    },
+    "paths": {
+      "type": "object",
+      "required": ["job_spec", "report", "eval_results", "artifact"],
+      "properties": {
+        "job_spec": { "type": "string" },
+        "report": { "type": "string" },
+        "eval_results": { "type": "string" },
+        "artifact": { "type": "string" }
+      }
+    },
+    "deployment": {
+      "type": "object",
+      "required": ["one_click_polaris_url", "health_url", "ready_url"],
+      "properties": {
+        "one_click_polaris_url": { "type": "string", "format": "uri" },
+        "health_url": { "type": "string", "format": "uri" },
+        "ready_url": { "type": "string", "format": "uri" }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "required": [
+        "baseline_credits_per_task",
+        "optimized_credits_per_task",
+        "baseline_latency_seconds",
+        "optimized_latency_seconds",
+        "baseline_failure_rate",
+        "optimized_failure_rate"
+      ],
+      "properties": {
+        "baseline_credits_per_task": { "type": "number", "exclusiveMinimum": 0 },
+        "optimized_credits_per_task": { "type": "number", "exclusiveMinimum": 0 },
+        "baseline_latency_seconds": { "type": "number", "exclusiveMinimum": 0 },
+        "optimized_latency_seconds": { "type": "number", "exclusiveMinimum": 0 },
+        "baseline_failure_rate": { "type": "number", "minimum": 0, "maximum": 1 },
+        "optimized_failure_rate": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "quality": {
+      "type": "object",
+      "required": ["held_out_eval_id", "outcome_retention", "citation_correctness", "known_tradeoffs"],
+      "properties": {
+        "held_out_eval_id": { "type": "string" },
+        "outcome_retention": { "type": "number", "minimum": 0, "maximum": 1 },
+        "citation_correctness": { "type": "number", "minimum": 0, "maximum": 1 },
+        "known_tradeoffs": { "type": "string" }
+      }
+    },
+    "usage_attribution": {
+      "type": "object",
+      "required": ["attribution_url", "artifact_event_name", "exclude_creator_owned_usage"],
+      "properties": {
+        "attribution_url": { "type": "string", "format": "uri" },
+        "artifact_event_name": { "type": "string" },
+        "exclude_creator_owned_usage": { "type": "boolean" }
+      }
+    },
+    "disqualifier_attestations": {
+      "type": "object",
+      "required": [
+        "not_model_only",
+        "not_public_benchmark_only",
+        "not_dataset_only",
+        "reproducible_from_job_spec",
+        "does_not_count_self_deploy_as_demand"
+      ],
+      "properties": {
+        "not_model_only": { "type": "boolean" },
+        "not_public_benchmark_only": { "type": "boolean" },
+        "not_dataset_only": { "type": "boolean" },
+        "reproducible_from_job_spec": { "type": "boolean" },
+        "does_not_count_self_deploy_as_demand": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/justfile
+++ b/justfile
@@ -373,6 +373,14 @@ localnet-restart:
     cd scripts/localnet && ./restart.sh
 
 # =============================================================================
+# COST-COLLAPSE
+# =============================================================================
+
+# Run cost-collapse submission preflight
+cost-collapse-preflight MANIFEST="docs/cost-collapse/starter-kit/submission-manifest.example.json":
+    python3 scripts/cost-collapse/preflight.py {{MANIFEST}} --root docs/cost-collapse/starter-kit
+
+# =============================================================================
 # PYTHON SDK
 # =============================================================================
 

--- a/scripts/cost-collapse/preflight.py
+++ b/scripts/cost-collapse/preflight.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Preflight a Cathedral cost-collapse submission manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+ALLOWED_TYPES = {
+    "distilled_model",
+    "lora_adapter",
+    "router",
+    "prompt_compression_recipe",
+    "specialized_judge",
+    "cached_tool_plan_policy",
+    "retrieval_pack",
+    "trace_dataset_with_eval_harness",
+    "failure_diagnosis",
+}
+
+REQUIRED_ATTESTATIONS = {
+    "not_model_only",
+    "not_public_benchmark_only",
+    "not_dataset_only",
+    "reproducible_from_job_spec",
+    "does_not_count_self_deploy_as_demand",
+}
+
+REQUIRED_PATHS = {
+    "job_spec",
+    "report",
+    "eval_results",
+    "artifact",
+}
+
+MIN_OUTCOME_RETENTION = 0.85
+MIN_CITATION_CORRECTNESS = 0.85
+
+
+def nested(data: dict, path: str):
+    current = data
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def is_https_url(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    parsed = urlparse(value)
+    return parsed.scheme == "https" and bool(parsed.netloc)
+
+
+def is_positive_number(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0
+
+
+def is_rate(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and 0 <= value <= 1
+
+
+def resolve_manifest_path(root: Path, value: object) -> Path | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    return candidate.resolve()
+
+
+def validate(data: dict, manifest_path: Path, root: Path) -> tuple[list[str], list[str]]:
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    if nested(data, "schema_version") != "cathedral.cost_collapse.submission_manifest.v1":
+        failures.append("schema_version must be cathedral.cost_collapse.submission_manifest.v1")
+
+    if nested(data, "competition_id") != "bittensor-subnet-analyst-compression":
+        failures.append("competition_id must be bittensor-subnet-analyst-compression")
+
+    artifact_type = nested(data, "artifact.type")
+    if artifact_type not in ALLOWED_TYPES:
+        failures.append(f"artifact.type must be one of: {', '.join(sorted(ALLOWED_TYPES))}")
+
+    summary = nested(data, "artifact.summary")
+    if not isinstance(summary, str) or len(summary.strip()) < 20:
+        failures.append("artifact.summary must explain the intervention in at least 20 characters")
+
+    for field in [
+        "deployment.one_click_polaris_url",
+        "deployment.health_url",
+        "deployment.ready_url",
+        "usage_attribution.attribution_url",
+    ]:
+        if not is_https_url(nested(data, field)):
+            failures.append(f"{field} must be an https URL")
+
+    polaris_url = nested(data, "deployment.one_click_polaris_url")
+    if isinstance(polaris_url, str) and "polaris" not in urlparse(polaris_url).netloc:
+        warnings.append("deployment.one_click_polaris_url does not appear to point at a Polaris host")
+
+    paths = nested(data, "paths")
+    if not isinstance(paths, dict):
+        failures.append("paths must be an object")
+    else:
+        for key in REQUIRED_PATHS:
+            resolved = resolve_manifest_path(root, paths.get(key))
+            if resolved is None:
+                failures.append(f"paths.{key} is required")
+            elif not resolved.exists():
+                failures.append(f"paths.{key} does not exist: {resolved}")
+
+    metrics = nested(data, "metrics")
+    if not isinstance(metrics, dict):
+        failures.append("metrics must be an object")
+    else:
+        for key in [
+            "baseline_credits_per_task",
+            "optimized_credits_per_task",
+            "baseline_latency_seconds",
+            "optimized_latency_seconds",
+        ]:
+            if not is_positive_number(metrics.get(key)):
+                failures.append(f"metrics.{key} must be a positive number")
+        for key in ["baseline_failure_rate", "optimized_failure_rate"]:
+            if not is_rate(metrics.get(key)):
+                failures.append(f"metrics.{key} must be between 0 and 1")
+
+        baseline_cost = metrics.get("baseline_credits_per_task")
+        optimized_cost = metrics.get("optimized_credits_per_task")
+        if is_positive_number(baseline_cost) and is_positive_number(optimized_cost):
+            if optimized_cost >= baseline_cost:
+                failures.append("optimized_credits_per_task must be lower than baseline_credits_per_task")
+
+        baseline_latency = metrics.get("baseline_latency_seconds")
+        optimized_latency = metrics.get("optimized_latency_seconds")
+        if is_positive_number(baseline_latency) and is_positive_number(optimized_latency):
+            if optimized_latency > baseline_latency:
+                warnings.append("optimized latency is higher than baseline latency, demand handoff must explain why")
+
+        baseline_failure = metrics.get("baseline_failure_rate")
+        optimized_failure = metrics.get("optimized_failure_rate")
+        if is_rate(baseline_failure) and is_rate(optimized_failure):
+            allowed_failure = max(float(baseline_failure) + 0.05, float(baseline_failure) * 1.5)
+            if float(optimized_failure) > allowed_failure:
+                failures.append("optimized_failure_rate increases too much vs baseline_failure_rate")
+
+    quality = nested(data, "quality")
+    if not isinstance(quality, dict):
+        failures.append("quality must be an object")
+    else:
+        if not is_rate(quality.get("outcome_retention")):
+            failures.append("quality.outcome_retention must be between 0 and 1")
+        elif float(quality["outcome_retention"]) < MIN_OUTCOME_RETENTION:
+            failures.append(f"quality.outcome_retention must be at least {MIN_OUTCOME_RETENTION}")
+
+        if not is_rate(quality.get("citation_correctness")):
+            failures.append("quality.citation_correctness must be between 0 and 1")
+        elif float(quality["citation_correctness"]) < MIN_CITATION_CORRECTNESS:
+            failures.append(f"quality.citation_correctness must be at least {MIN_CITATION_CORRECTNESS}")
+
+        tradeoffs = quality.get("known_tradeoffs")
+        if not isinstance(tradeoffs, str) or len(tradeoffs.strip()) < 20:
+            failures.append("quality.known_tradeoffs must disclose material tradeoffs")
+
+    attribution = nested(data, "usage_attribution")
+    if not isinstance(attribution, dict):
+        failures.append("usage_attribution must be an object")
+    else:
+        if attribution.get("exclude_creator_owned_usage") is not True:
+            failures.append("usage_attribution.exclude_creator_owned_usage must be true")
+        if not isinstance(attribution.get("artifact_event_name"), str) or not attribution["artifact_event_name"].strip():
+            failures.append("usage_attribution.artifact_event_name is required")
+
+    attestations = nested(data, "disqualifier_attestations")
+    if not isinstance(attestations, dict):
+        failures.append("disqualifier_attestations must be an object")
+    else:
+        for key in REQUIRED_ATTESTATIONS:
+            if attestations.get(key) is not True:
+                failures.append(f"disqualifier_attestations.{key} must be true")
+
+    if failures:
+        warnings.append("preflight failing means the submission is ineligible for scoring")
+    elif manifest_path.name == "submission-manifest.example.json":
+        warnings.append("example manifest passes shape checks, replace placeholders before real submission")
+
+    return failures, warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Preflight a Cathedral cost-collapse submission manifest.")
+    parser.add_argument("manifest", type=Path, help="Path to submission-manifest.json")
+    parser.add_argument("--root", type=Path, default=None, help="Root directory used to resolve relative file paths")
+    args = parser.parse_args()
+
+    manifest_path = args.manifest.resolve()
+    root = (args.root.resolve() if args.root else manifest_path.parent.resolve())
+
+    try:
+        data = json.loads(manifest_path.read_text())
+    except FileNotFoundError:
+        print(f"FAIL manifest not found: {manifest_path}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"FAIL manifest is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    failures, warnings = validate(data, manifest_path, root)
+
+    print("Cathedral cost-collapse preflight")
+    print(f"manifest: {manifest_path}")
+    print(f"root: {root}")
+
+    if warnings:
+        print("\nWarnings:")
+        for warning in warnings:
+            print(f"  WARN {warning}")
+
+    if failures:
+        print("\nFailures:")
+        for failure in failures:
+            print(f"  FAIL {failure}")
+        return 1
+
+    print("\nPASS submission is eligible for scoring intake")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/cost-collapse/fixtures/artifact/README.md
+++ b/tests/cost-collapse/fixtures/artifact/README.md
@@ -1,0 +1,3 @@
+# Example Artifact
+
+This placeholder represents a deployable optimization artifact or eval harness.

--- a/tests/cost-collapse/fixtures/eval-results.example.json
+++ b/tests/cost-collapse/fixtures/eval-results.example.json
@@ -1,0 +1,8 @@
+{
+  "held_out_eval_id": "subnet-analyst-heldout-v0",
+  "tasks": 20,
+  "outcome_retention": 0.9,
+  "citation_correctness": 0.92,
+  "risk_detection": 0.88,
+  "demand_vs_supply_reasoning": 0.91
+}

--- a/tests/cost-collapse/fixtures/invalid-model-only-manifest.json
+++ b/tests/cost-collapse/fixtures/invalid-model-only-manifest.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "cathedral.cost_collapse.submission_manifest.v1",
+  "competition_id": "bittensor-subnet-analyst-compression",
+  "artifact": {
+    "id": "model-only",
+    "name": "Model Only",
+    "type": "distilled_model",
+    "summary": "A model upload with no deployment or attribution path."
+  },
+  "creator": {
+    "name": "Example Builder",
+    "contact": "builder@example.com",
+    "bittensor_hotkey": "5ExampleHotkeyReplaceMe"
+  },
+  "paths": {
+    "job_spec": "missing-job-spec.yaml",
+    "report": "missing-report.md",
+    "eval_results": "missing-eval.json",
+    "artifact": "missing-artifact"
+  },
+  "deployment": {
+    "one_click_polaris_url": "http://example.com/deploy",
+    "health_url": "http://example.com/health",
+    "ready_url": "http://example.com/ready"
+  },
+  "metrics": {
+    "baseline_credits_per_task": 1.0,
+    "optimized_credits_per_task": 1.2,
+    "baseline_latency_seconds": 120.0,
+    "optimized_latency_seconds": 140.0,
+    "baseline_failure_rate": 0.04,
+    "optimized_failure_rate": 0.4
+  },
+  "quality": {
+    "held_out_eval_id": "subnet-analyst-heldout-v0",
+    "outcome_retention": 0.7,
+    "citation_correctness": 0.7,
+    "known_tradeoffs": "Poor quality."
+  },
+  "usage_attribution": {
+    "attribution_url": "http://example.com/attribution",
+    "artifact_event_name": "",
+    "exclude_creator_owned_usage": false
+  },
+  "disqualifier_attestations": {
+    "not_model_only": false,
+    "not_public_benchmark_only": false,
+    "not_dataset_only": true,
+    "reproducible_from_job_spec": false,
+    "does_not_count_self_deploy_as_demand": false
+  }
+}


### PR DESCRIPTION
## Summary

Adds the Cathedral supply-side package for the first cost-collapse sprint, centered on Bittensor Subnet Analyst Compression.

Changes:
- Adds the miner brief, public call, recruiting DM, scoring table, disqualification rules, and demand handoff template.
- Adds the starter kit with job spec, manifest schema, example manifest, report template, eligibility checklist, and invalid submission examples.
- Adds a standard-library preflight checker for manifest shape, required files, deployment links, attribution path, cost delta, quality gates, and disqualifier attestations.
- Adds valid and invalid fixtures plus a `just cost-collapse-preflight` command.

## Test Plan

- `python3 -m py_compile scripts/cost-collapse/preflight.py`
- `python3 scripts/cost-collapse/preflight.py docs/cost-collapse/starter-kit/submission-manifest.example.json --root docs/cost-collapse/starter-kit`
- `python3 scripts/cost-collapse/preflight.py tests/cost-collapse/fixtures/invalid-model-only-manifest.json --root docs/cost-collapse/starter-kit` verified nonzero failure
- `just cost-collapse-preflight`
- `rg -n "—|–" docs/cost-collapse scripts/cost-collapse tests/cost-collapse docs/README.md justfile` returned no matches

## Follow-up Issues

Refs #55
Refs #56
Refs #57
