### PR TITLE
docs(cost-collapse): record internal dry run

### DIFF
--- a/docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/artifact/README.md
+++ b/docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/artifact/README.md
@@ -1,0 +1,5 @@
+# Dry-Run Artifact
+
+This artifact is an internal harness record, not a model submission.
+
+It exists to prove that Polaris can record baseline, optimized, and eval runs, then expose proof and attribution URLs that Cathedral can validate.

--- a/docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/cost-latency-quality-report.md
+++ b/docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/cost-latency-quality-report.md
@@ -1,0 +1,56 @@
+# Cost, Latency, And Task-Quality Report
+
+## Artifact
+
+- artifact id: dry-run-optimized-artifact-v0
+- artifact type: trace dataset with eval harness
+- creator: Polaris internal dry run
+- competition id: bittensor-subnet-analyst-compression
+
+## Baseline
+
+- Polaris workflow id: polaris-cost-collapse-dry-run-v0
+- trace window: 2026-05-08T16:29:42Z..2026-05-08T16:29:48Z
+- median credits per task: 1.0
+- median latency seconds: 120.0
+- failure rate: 0.0
+- baseline deployment link: https://polaris.computer/deploy/dry-run-optimized-artifact-v0
+- baseline proof: https://api.polaris.computer/api/cost-collapse/proof/d13a313a-01f9-4d26-b1a6-69e61620ad37
+
+## Optimized Artifact
+
+- one-click Polaris deployment link: https://polaris.computer/deploy/dry-run-optimized-artifact-v0
+- attribution URL: https://api.polaris.computer/api/cost-collapse/attribution/dry-run-optimized-artifact-v0
+- optimized proof: https://api.polaris.computer/api/cost-collapse/proof/c32c1055-cd0b-4915-b72a-01dbbfafd37e
+- eval proof: https://api.polaris.computer/api/cost-collapse/proof/2edaa951-81e1-424a-9e9f-f4f75fa5f78b
+- health URL: https://api.polaris.computer/health
+- ready URL: https://api.polaris.computer/health
+- runtime profile: cost-collapse-dry-run
+
+## Eval
+
+- held-out eval id: cost-collapse-internal-ledger-dry-run-v0
+- eval command: `python3 scripts/cost-collapse/record_dry_run.py --base-url https://api.polaris.computer`
+- number of tasks: 1 dry-run fixture
+- outcome retention: 0.90
+- citation correctness: 0.90
+- risk-detection score: 0.90
+- demand-vs-supply score: 0.90
+
+## Delta
+
+| Metric | Baseline | Optimized | Delta |
+|---|---:|---:|---:|
+| credits per task | 1.00 | 0.35 | 65% lower |
+| latency seconds | 120.0 | 45.0 | 62.5% lower |
+| failure rate | 0.0 | 0.0 | no change |
+| outcome quality | 1.00 | 0.90 | 10% lower |
+| citation correctness | 1.00 | 0.90 | 10% lower |
+
+## Known Tradeoffs
+
+This dry run validates Polaris run records, proof links, attribution links, and exclusion logic. It does not prove a real model improvement or external demand.
+
+## Maintenance Plan
+
+Re-run after changes to Polaris cost-collapse endpoints, Cathedral preflight, reward eligibility flags, or artifact manifest schema.

--- a/docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/demand-handoff.md
+++ b/docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/demand-handoff.md
@@ -1,0 +1,23 @@
+# Demand Handoff
+
+| Field | Value |
+|---|---|
+| artifact id | dry-run-optimized-artifact-v0 |
+| creator | Polaris internal dry run |
+| intervention type | trace dataset with eval harness |
+| baseline workflow id | polaris-cost-collapse-dry-run-v0 |
+| optimized deployment link | https://polaris.computer/deploy/dry-run-optimized-artifact-v0 |
+| attribution path | https://api.polaris.computer/api/cost-collapse/attribution/dry-run-optimized-artifact-v0 |
+| held-out eval id | cost-collapse-internal-ledger-dry-run-v0 |
+| quality retention | 0.90 |
+| baseline credits per task | 1.00 |
+| optimized credits per task | 0.35 |
+| baseline latency seconds | 120.0 |
+| optimized latency seconds | 45.0 |
+| known quality tradeoff | Dry-run quality scores are fixtures, not model evidence. |
+| failure mode to watch | First-party usage must remain excluded from rewardable demand. |
+| target external users | none |
+| demand test owner | Polaris |
+| accepted for public launch | no |
+
+This run is first-party and non-eligible for rewards. It proves the ledger, proof, attribution, and exclusion path only.

--- a/docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/eval-results.json
+++ b/docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/eval-results.json
@@ -1,0 +1,14 @@
+{
+  "held_out_eval_id": "cost-collapse-internal-ledger-dry-run-v0",
+  "task_count": 1,
+  "outcome_retention": 0.9,
+  "citation_correctness": 0.9,
+  "risk_detection_score": 0.9,
+  "demand_vs_supply_score": 0.9,
+  "baseline_proof_url": "https://api.polaris.computer/api/cost-collapse/proof/d13a313a-01f9-4d26-b1a6-69e61620ad37",
+  "optimized_proof_url": "https://api.polaris.computer/api/cost-collapse/proof/c32c1055-cd0b-4915-b72a-01dbbfafd37e",
+  "eval_proof_url": "https://api.polaris.computer/api/cost-collapse/proof/2edaa951-81e1-424a-9e9f-f4f75fa5f78b",
+  "attribution_url": "https://api.polaris.computer/api/cost-collapse/attribution/dry-run-optimized-artifact-v0",
+  "eligible_credits_micros": 0,
+  "first_party_exclusion_count": 2
+}

--- a/docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/job-spec.yaml
+++ b/docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/job-spec.yaml
@@ -1,0 +1,39 @@
+schema_version: cathedral.cost_collapse.job_spec.v1
+competition_id: bittensor-subnet-analyst-compression
+artifact_id: dry-run-optimized-artifact-v0
+creator:
+  name: Polaris internal dry run
+  contact: fred@polaris.computer
+  bittensor_hotkey: internal-not-reward-eligible
+baseline:
+  workflow_id: polaris-cost-collapse-dry-run-v0
+  trace_window: 2026-05-08T16:29:42Z..2026-05-08T16:29:48Z
+  median_credits_per_task: 1.0
+  median_latency_seconds: 120.0
+  failure_rate: 0.0
+target:
+  task: Validate that Polaris can record baseline, optimized, and eval runs with proof and attribution URLs.
+  minimum_quality_retention: 0.85
+  required_capabilities:
+    - proof_url_generation
+    - artifact_attribution
+    - exclusion_flag_handling
+intervention:
+  type: trace_dataset_with_eval_harness
+  summary: Internal dry-run harness for testing Polaris proof and attribution paths before public rewards.
+  training_or_build_steps:
+    - Run `scripts/cost-collapse/record_dry_run.py` from the Polaris repo with a Polaris API token.
+runtime:
+  polaris_profile: cost-collapse-dry-run
+  container_image: not-applicable-api-ledger-dry-run
+  app_port: 0
+  health_path: /health
+  ready_path: /health
+  required_secrets:
+    - POLARIS_API_TOKEN
+eval:
+  held_out_eval_id: cost-collapse-internal-ledger-dry-run-v0
+  command: python3 scripts/cost-collapse/record_dry_run.py --base-url https://api.polaris.computer
+deployment:
+  one_click_polaris_url: https://polaris.computer/deploy/dry-run-optimized-artifact-v0
+  attribution_url: https://api.polaris.computer/api/cost-collapse/attribution/dry-run-optimized-artifact-v0

--- a/docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/submission-manifest.json
+++ b/docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/submission-manifest.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "cathedral.cost_collapse.submission_manifest.v1",
+  "competition_id": "bittensor-subnet-analyst-compression",
+  "artifact": {
+    "id": "dry-run-optimized-artifact-v0",
+    "name": "Polaris Cost-Collapse Ledger Dry Run",
+    "type": "trace_dataset_with_eval_harness",
+    "summary": "Internal dry-run harness that validates Polaris proof and attribution paths before public rewards."
+  },
+  "creator": {
+    "name": "Polaris internal dry run",
+    "contact": "fred@polaris.computer",
+    "bittensor_hotkey": "internal-not-reward-eligible"
+  },
+  "paths": {
+    "job_spec": "job-spec.yaml",
+    "report": "cost-latency-quality-report.md",
+    "eval_results": "eval-results.json",
+    "artifact": "artifact"
+  },
+  "deployment": {
+    "one_click_polaris_url": "https://polaris.computer/deploy/dry-run-optimized-artifact-v0",
+    "health_url": "https://api.polaris.computer/health",
+    "ready_url": "https://api.polaris.computer/health"
+  },
+  "metrics": {
+    "baseline_credits_per_task": 1.0,
+    "optimized_credits_per_task": 0.35,
+    "baseline_latency_seconds": 120.0,
+    "optimized_latency_seconds": 45.0,
+    "baseline_failure_rate": 0.0,
+    "optimized_failure_rate": 0.0
+  },
+  "quality": {
+    "held_out_eval_id": "cost-collapse-internal-ledger-dry-run-v0",
+    "outcome_retention": 0.9,
+    "citation_correctness": 0.9,
+    "known_tradeoffs": "This dry run validates the ledger and attribution path only. It is not evidence of external demand or model quality."
+  },
+  "usage_attribution": {
+    "attribution_url": "https://api.polaris.computer/api/cost-collapse/attribution/dry-run-optimized-artifact-v0",
+    "artifact_event_name": "cost_collapse_artifact_deployed",
+    "exclude_creator_owned_usage": true
+  },
+  "disqualifier_attestations": {
+    "not_model_only": true,
+    "not_public_benchmark_only": true,
+    "not_dataset_only": true,
+    "reproducible_from_job_spec": true,
+    "does_not_count_self_deploy_as_demand": true
+  }
+}


### PR DESCRIPTION
## Summary
- Add a no-placeholder internal dry-run bundle for the Polaris cost-collapse ledger test.
- Capture live proof URLs, attribution URL, eval result, cost report, job spec, demand handoff, and artifact README.

## Validation
- python3 scripts/cost-collapse/preflight.py docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger/submission-manifest.json --root docs/cost-collapse/internal-dry-runs/2026-05-08-polaris-api-ledger

## Notes
- This is first-party and non-eligible usage. It proves pipeline mechanics, not demand.