### PR TITLE
Clarify SN39 validator config

### DIFF
--- a/config/cathedral-validator.toml.example
+++ b/config/cathedral-validator.toml.example
@@ -35,7 +35,7 @@ cache_miner_info_ttl = { secs = 300 }
 enable_worker_queue = false
 
 [verification.binary_validation]
-enabled = true
+# Presence of this block enables binary validation.
 validator_binary_path = "./bin/validator-binary/validator-binary"
 executor_binary_path = "./bin/executor-binary/executor-binary"
 execution_timeout_secs = 1200
@@ -54,7 +54,7 @@ retention_period = { secs = 604800 }
 collection_interval = { secs = 30 }
 
 [metrics.prometheus]
-host = "0.0.0.0"
+host = "127.0.0.1"
 port = 9090
 path = "/metrics"
 

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -33,12 +33,13 @@ Current Cathedral operator hotkey:
 ## Requirements
 
 - Linux server with stable network.
+- CPU-only is fine. The validator server does not need a GPU.
 - Rust toolchain for the source build path.
 - Bittensor CLI and a hotkey registered on SN39.
 - A hotkey with validator permit for production weight setting.
 - Inbound TCP `8080` for the validator API and advertised endpoint.
 - Inbound TCP `50052` for miner bid registration.
-- Optional private TCP `9090` for Prometheus metrics.
+- Local TCP `9090` for Prometheus metrics. Expose it only through a firewall, VPN, or SSH tunnel.
 - Outbound SSH to miner machines.
 
 Keep the coldkey off the server. The validator server only needs the hotkey that signs validation and weight-setting operations.
@@ -66,6 +67,22 @@ network = "finney"
 netuid = 39
 external_ip = "YOUR_PUBLIC_IP"
 ```
+
+Keep these live-subnet defaults unless you know why you are changing them:
+
+```toml
+[metrics.prometheus]
+host = "127.0.0.1"
+port = 9090
+
+[emission]
+forced_burn_percentage = 95.0
+burn_uid = 204
+weight_set_interval_blocks = 360
+weight_version_key = 0
+```
+
+`[verification.binary_validation]` is enabled by the presence of that block. There is no separate `enabled = true` switch.
 
 Confirm your wallet can see SN39:
 


### PR DESCRIPTION
## Summary
- Keep the live SN39 forced-burn setting in the validator config example
- Remove the misleading `enabled = true` line from `verification.binary_validation`
- Bind Prometheus to localhost by default
- State clearly that the validator server can be CPU-only

## Validation
- Parsed `config/cathedral-validator.toml.example` with Python `tomllib`
- `git diff --check`

## Notes
This keeps the public handoff minimal: validators get the live config requirements without exposing the broader Cathedral mechanism.