### PR TITLE
Add validator guide directory copy

### DIFF
--- a/docs/validator/README.md
+++ b/docs/validator/README.md
@@ -2,6 +2,8 @@
 
 This is the validator handoff for Cathedral on Bittensor SN39.
 
+This folder copy exists so validators can use the cleaner GitHub directory link. The canonical single-file guide remains available at [docs/validator.md](../validator.md).
+
 Cathedral is in its compute-validation phase today. A validator runs the Cathedral validator, checks miner machines, records verification evidence, scores the available compute, and sets weights on SN39 from a permitted validator hotkey.
 
 The point of this handoff is to let SN39 validators run the validator themselves, or child-hotkey the Cathedral operator so the experiment can run end to end while the validator keeps control.


### PR DESCRIPTION
## Summary
- Add a docs/validator/README.md copy of the SN39 validator handoff so validators can use a cleaner GitHub directory link
- Keep the existing docs/validator.md file and blob link intact
- Add the directory link to the existing validator packet

## Validation
- Documentation-only change
- Confirmed branch is based on origin/main and contains only validator guide docs changes