### PR TITLE
Add regulatory intelligence worker kit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This directory contains comprehensive documentation for the Basilica decentraliz
 - **[Validator Guide](validator.md)** - Deploy and manage validator nodes for network verification
 - **[Miner Guide](miner.md)** - Set up miners to orchestrate GPU node access via SSH
 - **[Cost-Collapse Supply Kit](cost-collapse/README.md)** - Recruit and preflight miner submissions for Polaris workflow optimization assets
+- **[Regulatory Intelligence Kit](regulatory-intelligence/README.md)** - Run the first persistent worker card workflow for miners and validators
 
 ### Operations
 
@@ -57,6 +58,15 @@ Comprehensive miner setup and GPU node orchestration:
 - Validator SSH key deployment and access control
 - GPU verification through direct SSH access
 - Security best practices and troubleshooting
+
+### Regulatory Intelligence Kit
+
+The first persistent worker workflow for Cathedral:
+
+- one Hermes worker maintains one country card
+- cards cite official legal and regulator sources
+- validators score source quality, freshness, specificity, usefulness, and clarity
+- local preflight and e2e commands prove the loop before production rewards
 
 ### Monitoring Guide
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory contains comprehensive documentation for the Basilica decentraliz
 
 - **[Validator Guide](validator.md)** - Deploy and manage validator nodes for network verification
 - **[Miner Guide](miner.md)** - Set up miners to orchestrate GPU node access via SSH
+- **[Polaris Agent Identifier Contract](polaris-agent-contract.md)** - Miner claims use Polaris agent and artifact identifiers, not IP addresses
 - **[Cost-Collapse Supply Kit](cost-collapse/README.md)** - Recruit and preflight miner submissions for Polaris workflow optimization assets
 - **[Regulatory Intelligence Kit](regulatory-intelligence/README.md)** - Run the first persistent worker card workflow for miners and validators
 

--- a/docs/miner.md
+++ b/docs/miner.md
@@ -1,5 +1,12 @@
 # Running a Cathedral Miner
 
+Cathedral now has two miner tracks:
+
+1. Compute miners provide machines that validators can inspect.
+2. Regulatory intelligence miners run Hermes workers on Polaris and maintain country cards.
+
+For the regulatory worker path, start here: [docs/regulatory-intelligence/miner.md](regulatory-intelligence/miner.md).
+
 This guide gets you from zero to a registered miner on Cathedral (Bittensor Subnet 39) in roughly an hour. It assumes you already have a Bittensor wallet and an SSH-accessible GPU box.
 
 > **Status:** Cathedral is early. Weight-setting is currently blocked on validator stake. Miners can register, pass verification, and accumulate CUs, but emissions won't flow until the stake threshold is met. See [docs/policy.md](policy.md).

--- a/docs/polaris-agent-claim.schema.json
+++ b/docs/polaris-agent-claim.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cathedral.computer/schemas/polaris-agent-claim.v1.json",
+  "title": "Cathedral Polaris Agent Claim",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "claim_id",
+    "work_unit",
+    "miner_hotkey",
+    "owner_wallet",
+    "polaris_agent_id",
+    "submitted_at",
+    "miner_signature"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "cathedral.polaris_agent_claim.v1"
+    },
+    "claim_id": {
+      "type": "string",
+      "minLength": 6,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.:-]+$"
+    },
+    "work_unit": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 96,
+      "pattern": "^[a-z0-9_:-]+$"
+    },
+    "miner_hotkey": {
+      "type": "string",
+      "minLength": 16,
+      "maxLength": 128
+    },
+    "owner_wallet": {
+      "type": "string",
+      "minLength": 16,
+      "maxLength": 128
+    },
+    "polaris_agent_id": {
+      "type": "string",
+      "minLength": 6,
+      "maxLength": 128,
+      "pattern": "^(agt|agent)_[A-Za-z0-9_.:-]+$"
+    },
+    "polaris_deployment_id": {
+      "type": "string",
+      "minLength": 6,
+      "maxLength": 128
+    },
+    "polaris_run_id": {
+      "type": "string",
+      "minLength": 6,
+      "maxLength": 128
+    },
+    "polaris_artifact_id": {
+      "type": "string",
+      "minLength": 6,
+      "maxLength": 128
+    },
+    "declared_capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 64,
+        "pattern": "^[a-z0-9_:-]+$"
+      },
+      "uniqueItems": true,
+      "maxItems": 24
+    },
+    "submitted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "miner_signature": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 512
+    }
+  },
+  "anyOf": [
+    {
+      "required": ["polaris_deployment_id"]
+    },
+    {
+      "required": ["polaris_run_id"]
+    },
+    {
+      "required": ["polaris_artifact_id"]
+    }
+  ]
+}

--- a/docs/polaris-agent-contract.md
+++ b/docs/polaris-agent-contract.md
@@ -1,0 +1,247 @@
+# Polaris Agent Identifier Contract
+
+Status: v0.1 draft
+
+This contract defines how Cathedral scores Polaris-hosted agent work without using miner IP addresses as the product interface.
+
+## Core rule
+
+Miners submit agent identifiers to Cathedral. Cathedral pulls evidence from Polaris.
+
+The miner does not submit an IP address as proof. The miner submits a claim that points to a Polaris agent, deployment, artifact, or run. Cathedral then asks Polaris for signed records that prove what happened.
+
+On-chain axon IP and port may still exist for Bittensor validator plumbing. They are not the contract for ModelFactory, regulatory intelligence cards, or other Polaris-hosted work units.
+
+## Why this replaces IP-first flow
+
+The old compute-miner path needed validators to discover miner hosts and connect to them directly. That is useful for raw compute validation, but it is the wrong primitive for Polaris-hosted agent work.
+
+For agent work, Polaris already owns:
+
+- runtime identity
+- deployment identity
+- agent health
+- run records
+- traces
+- artifact hashes
+- usage ledger
+- credit spend attribution
+- abuse flags
+
+Cathedral should consume those records instead of trying to infer product state from subnet IPs.
+
+## Identifiers
+
+| Identifier | Owner | Meaning |
+| --- | --- | --- |
+| `polaris_agent_id` | Polaris | Stable identity for a worker or agent profile. Example: `agt_reg_eu_ai_act_001`. |
+| `polaris_deployment_id` | Polaris | Runtime deployment that runs the agent. Can change across upgrades. |
+| `polaris_run_id` | Polaris | One execution, job, card refresh, eval, or task attempt. |
+| `polaris_artifact_id` | Polaris | Output asset: model, LoRA, router, card, eval report, dataset, or deployable harness. |
+| `cathedral_claim_id` | Cathedral | Submission record created when a miner asks Cathedral to score Polaris work. |
+| `miner_hotkey` | Bittensor | Miner identity for reward attribution. |
+| `owner_wallet` | Polaris and Cathedral | Wallet or account that controls the agent or artifact. |
+
+## Miner claim
+
+A miner submits this to Cathedral:
+
+```json
+{
+  "schema_version": "cathedral.polaris_agent_claim.v1",
+  "claim_id": "claim_2026_05_10_001",
+  "work_unit": "regulatory_intelligence_card",
+  "miner_hotkey": "5F...",
+  "owner_wallet": "5F...",
+  "polaris_agent_id": "agt_reg_eu_ai_act_001",
+  "polaris_deployment_id": "dep_01HX...",
+  "polaris_artifact_id": "art_eu_ai_act_2026_05_10",
+  "declared_capabilities": ["research", "summarize", "cite_sources"],
+  "submitted_at": "2026-05-10T00:00:00Z",
+  "miner_signature": "0x..."
+}
+```
+
+The claim is not enough to receive rewards. It only tells Cathedral what to verify.
+
+## Cathedral pull flow
+
+1. Miner submits a claim with Polaris identifiers.
+2. Cathedral checks claim shape and miner identity.
+3. Cathedral calls Polaris for the agent manifest.
+4. Cathedral checks ownership and work-unit eligibility.
+5. Cathedral pulls run records, artifact records, and usage records.
+6. Cathedral verifies signatures, hashes, and abuse flags.
+7. Cathedral scores the work unit.
+8. Cathedral emits reward weights from verified evidence.
+
+## Required Polaris endpoints
+
+Polaris should expose a Cathedral-scoped API surface:
+
+```text
+GET /api/cathedral/v1/agents/{polaris_agent_id}/manifest
+GET /api/cathedral/v1/agents/{polaris_agent_id}/health
+GET /api/cathedral/v1/agents/{polaris_agent_id}/runs?cursor=...
+GET /api/cathedral/v1/runs/{polaris_run_id}
+GET /api/cathedral/v1/artifacts/{polaris_artifact_id}
+GET /api/cathedral/v1/artifacts/{polaris_artifact_id}/usage?cursor=...
+GET /api/cathedral/v1/events?cursor=...
+GET /.well-known/polaris/cathedral-jwks.json
+```
+
+Optional helper:
+
+```text
+POST /api/cathedral/v1/claims/verify
+```
+
+`claims/verify` can return a single verification bundle, but Cathedral must still be able to pull records independently.
+
+## Agent manifest
+
+```json
+{
+  "schema_version": "polaris.cathedral.agent_manifest.v1",
+  "polaris_agent_id": "agt_reg_eu_ai_act_001",
+  "polaris_deployment_id": "dep_01HX...",
+  "runtime": "hermes",
+  "work_unit": "regulatory_intelligence_card",
+  "owner_wallet": "5F...",
+  "miner_hotkey": "5F...",
+  "status": "running",
+  "created_at": "2026-05-10T00:00:00Z",
+  "updated_at": "2026-05-10T00:30:00Z",
+  "capabilities": ["research", "summarize", "cite_sources"],
+  "config_version": "v1.0.3",
+  "deployment_url": "https://polaris.computer/computer/agents/agt_reg_eu_ai_act_001",
+  "proof_url": "https://polaris.computer/proof/dep_01HX...",
+  "latest_artifact_ids": ["art_eu_ai_act_2026_05_10"],
+  "signature": {
+    "issuer": "polaris",
+    "key_id": "polaris-cathedral-2026-05",
+    "alg": "Ed25519",
+    "value": "..."
+  }
+}
+```
+
+## Artifact record
+
+```json
+{
+  "schema_version": "polaris.cathedral.artifact.v1",
+  "polaris_artifact_id": "art_eu_ai_act_2026_05_10",
+  "polaris_agent_id": "agt_reg_eu_ai_act_001",
+  "polaris_run_id": "run_01HX...",
+  "work_unit": "regulatory_intelligence_card",
+  "artifact_type": "regulatory_card",
+  "artifact_hash": "sha256:...",
+  "content_url": "https://api.polaris.computer/api/cathedral/v1/artifacts/art_eu_ai_act_2026_05_10/content",
+  "eval_report_url": "https://api.polaris.computer/api/cathedral/v1/artifacts/art_eu_ai_act_2026_05_10/eval",
+  "created_at": "2026-05-10T00:30:00Z",
+  "signature": {
+    "issuer": "polaris",
+    "key_id": "polaris-cathedral-2026-05",
+    "alg": "Ed25519",
+    "value": "..."
+  }
+}
+```
+
+## Usage record
+
+```json
+{
+  "schema_version": "polaris.cathedral.usage.v1",
+  "usage_id": "use_01HX...",
+  "polaris_artifact_id": "art_eu_ai_act_2026_05_10",
+  "polaris_agent_id": "agt_reg_eu_ai_act_001",
+  "consumer_wallet": "5G...",
+  "credits_spent": 0.18,
+  "started_at": "2026-05-10T01:00:00Z",
+  "ended_at": "2026-05-10T01:08:00Z",
+  "excluded_from_rewards": false,
+  "exclude_reason": null,
+  "signature": {
+    "issuer": "polaris",
+    "key_id": "polaris-cathedral-2026-05",
+    "alg": "Ed25519",
+    "value": "..."
+  }
+}
+```
+
+Excluded usage must include a reason:
+
+- `creator_owned`
+- `platform_owned`
+- `refunded`
+- `abuse_flagged`
+- `test_usage`
+- `self_loop`
+
+## Signed event envelope
+
+Polaris events consumed by Cathedral should use one envelope:
+
+```json
+{
+  "schema_version": "polaris.cathedral.event.v1",
+  "event_id": "evt_01HX...",
+  "event_type": "artifact_used",
+  "occurred_at": "2026-05-10T01:08:00Z",
+  "subject": {
+    "polaris_agent_id": "agt_reg_eu_ai_act_001",
+    "polaris_artifact_id": "art_eu_ai_act_2026_05_10",
+    "miner_hotkey": "5F..."
+  },
+  "payload_hash": "sha256:...",
+  "payload": {},
+  "signature": {
+    "issuer": "polaris",
+    "key_id": "polaris-cathedral-2026-05",
+    "alg": "Ed25519",
+    "value": "..."
+  }
+}
+```
+
+Cathedral validates the signature before using the event for scoring.
+
+## Cathedral validation rules
+
+A claim is eligible only if:
+
+1. The claim matches the JSON schema.
+2. The miner hotkey is registered or explicitly allowed for the work unit.
+3. Polaris returns a signed manifest for `polaris_agent_id`.
+4. The manifest owner matches the claim owner or an allowed delegation.
+5. The agent runtime is eligible for the work unit.
+6. The artifact hash matches the content Polaris serves.
+7. The run record proves the artifact came from the claimed deployment.
+8. The usage records exclude self-usage, platform-owned usage, refunded usage, test usage, and abuse-flagged usage.
+9. The artifact remains deployable or maintained for ongoing rewards.
+
+## What Cathedral must not trust
+
+- self-reported miner IP
+- screenshots
+- frontend-only URLs without signed backend records
+- public benchmark claims without hidden or Cathedral-controlled evals
+- creator-owned usage
+- platform-owned usage
+- unsigned Polaris event JSON
+
+## Versioning
+
+This contract uses explicit schema versions. Breaking changes require a new schema version and a transition window.
+
+Current versions:
+
+- `cathedral.polaris_agent_claim.v1`
+- `polaris.cathedral.agent_manifest.v1`
+- `polaris.cathedral.artifact.v1`
+- `polaris.cathedral.usage.v1`
+- `polaris.cathedral.event.v1`
+

--- a/docs/regulatory-intelligence/README.md
+++ b/docs/regulatory-intelligence/README.md
@@ -1,0 +1,69 @@
+# Cathedral Regulatory Intelligence
+
+Cathedral now has a first concrete intelligence work unit:
+
+> Maintain country-level regulatory intelligence cards with persistent Hermes workers.
+
+This is not legal advice. It is a scored intelligence feed for people who need to track AI, data, compute, and digital regulation across jurisdictions.
+
+## What ships in this v1 kit
+
+- Miner work unit for one card per worker.
+- Validator preflight for source quality, schema validity, and anti-abuse checks.
+- Local end-to-end simulation of worker registration, job assignment, artifact intake, scoring, and reputation update.
+- Official source baseline for the first countries.
+- Polaris integration contract for worker runtime, usage events, and deploy links.
+
+## Simple loop
+
+1. Polaris runs a Hermes worker.
+2. The worker registers with Cathedral.
+3. Cathedral assigns one regulatory card.
+4. The worker updates that card daily from official sources.
+5. Cathedral validates the artifact and scores it.
+6. The best cards are published on cathedral.computer.
+7. Worker reputation updates over time.
+
+## Why this is a good first baseline
+
+- The output is understandable to non-ML users.
+- The source standard is clear: cite official government, regulator, or law text.
+- The card compounds because the same worker updates the same asset every day.
+- Validators can inspect evidence instead of trusting a leaderboard claim.
+- Polaris gets demand from persistent worker runtime, retrieval, storage, and inference.
+
+## Run locally
+
+```bash
+just regulatory-preflight
+just regulatory-e2e
+```
+
+The e2e report is written to:
+
+```text
+target/regulatory-intelligence/e2e-report.json
+target/regulatory-intelligence/e2e-report.md
+```
+
+## Current scope
+
+The first public surface is a feed of regulatory intelligence cards organized by country. Each card has:
+
+- country
+- topic
+- owner worker
+- last update
+- official source citations
+- status
+- score
+- confidence
+- clear action notes
+
+## Non-goals
+
+- No legal advice.
+- No open-ended chat product.
+- No generic agent marketplace.
+- No reward for raw compute alone inside this work unit.
+- No reward for uncited summaries or public benchmark claims.

--- a/docs/regulatory-intelligence/miner.md
+++ b/docs/regulatory-intelligence/miner.md
@@ -1,0 +1,113 @@
+# Miner Guide: Regulatory Intelligence Cards
+
+## Work unit
+
+A miner operates a persistent Hermes worker on Polaris and maintains one regulatory intelligence card.
+
+The card is a public asset. It should get better over time.
+
+## The job
+
+For one assigned country and topic:
+
+1. Check the approved official sources.
+2. Identify what changed or confirm no material change.
+3. Update the card with concise intelligence.
+4. Cite the sources used.
+5. Submit the artifact to Cathedral.
+
+## Eligible cards
+
+Initial card topics:
+
+- AI governance
+- data protection
+- model safety
+- compute or infrastructure policy
+- procurement and public sector AI use
+
+Initial countries:
+
+- European Union
+- United States
+- United Kingdom
+- Canada
+- Singapore
+- Japan
+- India
+- Australia
+- United Arab Emirates
+- China
+
+## Minimum artifact
+
+Every submission must include:
+
+- `artifact_id`
+- `card_id`
+- `worker_id`
+- `country`
+- `jurisdiction_code`
+- `title`
+- `summary`
+- `what_changed`
+- `why_it_matters`
+- `action_items`
+- `risks`
+- `citations`
+- `confidence`
+- `no_legal_advice`
+
+See:
+
+```text
+examples/regulatory-intelligence/artifact.sample.json
+```
+
+## Source rule
+
+Use official sources first:
+
+- statutes
+- regulations
+- government guidance
+- regulator guidance
+- official consultation pages
+- official press releases
+
+Secondary sources can help discovery, but they do not make a card eligible by themselves.
+
+## Worker rule
+
+One miner gets one card at a time. The card stays attached to that worker until:
+
+- the worker fails maintenance,
+- the worker submits low-quality updates repeatedly,
+- the worker is fired by governance,
+- or the worker hands off the card with a valid handoff note.
+
+## What gets rewarded
+
+Cathedral rewards maintained intelligence assets, not one-time posts.
+
+Rewards should consider:
+
+- source quality
+- freshness
+- usefulness
+- specificity
+- clarity
+- maintenance history
+- downstream usage on Polaris
+
+## What gets rejected
+
+The validator rejects:
+
+- uncited claims
+- legal advice phrased as instruction
+- made-up source URLs
+- private data
+- source summaries without official links
+- worker self-usage as demand
+- stale cards that claim to be current

--- a/docs/regulatory-intelligence/polaris-contract.md
+++ b/docs/regulatory-intelligence/polaris-contract.md
@@ -1,0 +1,105 @@
+# Polaris Contract for Cathedral Regulatory Intelligence
+
+Cathedral depends on Polaris for runtime, identity, and usage evidence.
+
+## Polaris owns
+
+- Hermes worker deployment
+- worker endpoint
+- runtime health
+- inference usage
+- storage
+- logs and traces
+- usage ledger
+- credit spend attribution
+- deploy links
+
+## Cathedral owns
+
+- worker registry
+- card registry
+- job assignment
+- artifact intake
+- scoring
+- reputation
+- public feed
+- reward feed
+
+## Worker endpoint contract
+
+A Hermes worker should expose:
+
+```text
+GET  /healthz
+GET  /manifest
+POST /jobs
+```
+
+### `GET /manifest`
+
+```json
+{
+  "worker_id": "polaris_worker_reg_eu_ai_act_001",
+  "runtime": "hermes",
+  "category": "regulatory_intelligence",
+  "capabilities": ["research", "summarize", "cite_sources"],
+  "config_version": "v1.0.0"
+}
+```
+
+### `POST /jobs`
+
+```json
+{
+  "job_id": "job_reg_eu_ai_act_2026_05_10",
+  "card_id": "eu_ai_act_watch",
+  "objective": "Update the EU AI Act watch card from approved official sources.",
+  "source_ids": ["eu_ai_act_eurlex", "eu_ai_act_commission"]
+}
+```
+
+The worker returns or posts an artifact matching:
+
+```text
+examples/regulatory-intelligence/artifact.sample.json
+```
+
+## Polaris events Cathedral needs
+
+```json
+{
+  "event_type": "worker_registered",
+  "worker_id": "polaris_worker_reg_eu_ai_act_001",
+  "wallet": "5F...",
+  "runtime": "hermes",
+  "deploy_url": "https://polaris.computer/deployments/...",
+  "timestamp": "2026-05-10T00:00:00Z"
+}
+```
+
+```json
+{
+  "event_type": "artifact_used",
+  "artifact_id": "artifact_eu_ai_act_2026_05_10",
+  "worker_id": "polaris_worker_reg_eu_ai_act_001",
+  "credits_spent": 0.18,
+  "consumer_wallet": "5G...",
+  "excluded": false,
+  "exclude_reason": null,
+  "timestamp": "2026-05-10T00:00:00Z"
+}
+```
+
+## Signing requirement
+
+Production events should be signed by Polaris and include:
+
+- event id
+- timestamp
+- worker id
+- wallet id
+- artifact hash
+- deployment id
+- signature
+
+The local e2e harness stubs this for now.

--- a/docs/regulatory-intelligence/polaris-contract.md
+++ b/docs/regulatory-intelligence/polaris-contract.md
@@ -2,6 +2,8 @@
 
 Cathedral depends on Polaris for runtime, identity, and usage evidence.
 
+This work unit follows the canonical [Polaris Agent Identifier Contract](../polaris-agent-contract.md). Miners submit Polaris agent, deployment, run, or artifact identifiers. Cathedral pulls signed Polaris records for verification. Miner IP addresses are not proof for this work unit.
+
 ## Polaris owns
 
 - Hermes worker deployment

--- a/docs/regulatory-intelligence/source-baseline.md
+++ b/docs/regulatory-intelligence/source-baseline.md
@@ -1,0 +1,35 @@
+# Official Source Baseline
+
+The v1 baseline uses official government, regulator, or law text sources.
+
+Source registry:
+
+```text
+examples/regulatory-intelligence/source-baseline.json
+```
+
+## Included jurisdictions
+
+- European Union
+- United States
+- United Kingdom
+- Canada
+- Singapore
+- Japan
+- India
+- Australia
+- United Arab Emirates
+- China
+
+## Reliability tiers
+
+- `primary_law`: enacted law, regulation, gazette, code, or official legal text.
+- `primary_regulator`: government or regulator guidance, consultation, press release, or framework.
+- `official_policy`: national strategy or official policy page.
+- `secondary_discovery`: not eligible as a citation by itself.
+
+## Citation rule
+
+Every published card must cite at least two approved sources when the jurisdiction has two or more approved sources in the registry.
+
+If a jurisdiction has one approved source, the card must cite that source and explicitly state what source coverage is missing.

--- a/docs/regulatory-intelligence/validator.md
+++ b/docs/regulatory-intelligence/validator.md
@@ -1,0 +1,64 @@
+# Validator Guide: Regulatory Intelligence Cards
+
+## Validator job
+
+The validator checks whether a regulatory intelligence artifact is eligible, useful, and maintained.
+
+It does not need to decide perfect legal truth in v1. It needs to reject obvious bad work and rank useful work.
+
+## Scoring inputs
+
+The v1 scorer uses:
+
+- source quality
+- source freshness
+- citation coverage
+- specificity
+- usefulness
+- clarity
+- maintenance history
+
+The local scorer is deterministic so validators can inspect it.
+
+## Required checks
+
+For each artifact:
+
+1. Schema is valid.
+2. `card_id` exists in the card registry.
+3. `worker_id` owns or is assigned the card.
+4. Citations point to approved official sources.
+5. The artifact says it is not legal advice.
+6. No private data is included.
+7. The update is specific enough to be useful.
+8. The artifact has a Polaris deploy or worker attribution path.
+
+## Abuse filters
+
+The reward path should exclude:
+
+- creator-owned usage
+- platform-owned test usage
+- refunded usage
+- usage flagged as abuse
+- synthetic loops between related wallets
+- artifacts with broken deploy links
+- artifacts that cannot be reproduced or inspected
+
+## Local commands
+
+```bash
+just regulatory-preflight
+just regulatory-e2e
+```
+
+## Score bands
+
+- `90-100`: publish and reward
+- `75-89`: publish if no material gaps
+- `60-74`: hold for review
+- `<60`: reject
+
+## Current limitation
+
+The v1 scorer is a local harness. Production validation still needs signed Polaris events, hidden challenger tasks, and live worker endpoint checks.

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -1,5 +1,12 @@
 # Cathedral SN39 Validator Handoff
 
+Cathedral now has two validator tracks:
+
+1. Compute validation checks whether miner machines are real and reachable.
+2. Regulatory intelligence validation checks whether worker cards are sourced, useful, maintained, and attributable to Polaris.
+
+For the regulatory worker validator path, start here: [docs/regulatory-intelligence/validator.md](regulatory-intelligence/validator.md).
+
 This is the validator handoff for Cathedral on Bittensor SN39.
 
 Cathedral is in its compute-validation phase today. A validator runs the Cathedral validator, checks miner machines, records verification evidence, scores the available compute, and sets weights on SN39 from a permitted validator hotkey.

--- a/examples/regulatory-intelligence/artifact.invalid.json
+++ b/examples/regulatory-intelligence/artifact.invalid.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "cathedral.regulatory_intelligence.artifact.v1",
+  "artifact_id": "artifact_invalid",
+  "card_id": "eu_ai_act_watch",
+  "job_id": "job_eu_ai_act_watch_2026_05_10",
+  "worker_id": "polaris_worker_reg_eu_ai_act_001",
+  "country": "European Union",
+  "jurisdiction_code": "EU",
+  "generated_at": "2026-05-10T00:00:00Z",
+  "title": "EU AI Act implementation watch",
+  "summary": "The law changed. You should comply immediately.",
+  "what_changed": "Something changed.",
+  "why_it_matters": "It matters.",
+  "action_items": ["Comply now."],
+  "risks": [],
+  "citations": [],
+  "confidence": 0.98,
+  "no_legal_advice": false,
+  "private_data_included": false,
+  "polaris": {
+    "worker_deploy_url": "",
+    "artifact_hash": "",
+    "usage_attribution_path": ""
+  },
+  "disqualifier_attestations": {
+    "not_legal_advice": false,
+    "no_confidential_data": true,
+    "citations_are_primary_sources": false,
+    "no_uncited_material_claims": false,
+    "does_not_count_self_usage_as_demand": true
+  }
+}

--- a/examples/regulatory-intelligence/artifact.sample.json
+++ b/examples/regulatory-intelligence/artifact.sample.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "cathedral.regulatory_intelligence.artifact.v1",
+  "artifact_id": "artifact_eu_ai_act_watch_2026_05_10",
+  "card_id": "eu_ai_act_watch",
+  "job_id": "job_eu_ai_act_watch_2026_05_10",
+  "worker_id": "polaris_worker_reg_eu_ai_act_001",
+  "country": "European Union",
+  "jurisdiction_code": "EU",
+  "generated_at": "2026-05-10T00:00:00Z",
+  "title": "EU AI Act implementation watch",
+  "summary": "The EU AI Act card should keep tracking obligation timing, high-risk AI duties, general-purpose AI rules, and Commission implementation guidance.",
+  "what_changed": "No material change is asserted in this sample artifact. The worker confirms that the card is anchored to Regulation (EU) 2024/1689 and the European Commission AI Act implementation page.",
+  "why_it_matters": "AI builders and deployers need one maintained place to track which duties apply, which dates matter, and which official implementation pages changed.",
+  "action_items": [
+    "Check whether the Commission AI Act page changed since the previous card update.",
+    "Keep the card separated between enacted legal text and Commission implementation guidance.",
+    "Flag any new guidance that changes duties for high-risk AI or general-purpose AI providers."
+  ],
+  "risks": [
+    "This card is regulatory intelligence, not legal advice.",
+    "Some implementation details may depend on later Commission guidance or national authority practice."
+  ],
+  "citations": [
+    {
+      "source_id": "eu_ai_act_eurlex",
+      "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689",
+      "retrieved_at": "2026-05-10T00:00:00Z",
+      "evidence_note": "Primary legal text for the AI Act."
+    },
+    {
+      "source_id": "eu_ai_act_commission",
+      "url": "https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai",
+      "retrieved_at": "2026-05-10T00:00:00Z",
+      "evidence_note": "Commission implementation and policy page."
+    }
+  ],
+  "confidence": 0.86,
+  "no_legal_advice": true,
+  "private_data_included": false,
+  "polaris": {
+    "worker_deploy_url": "https://polaris.computer/workers/polaris_worker_reg_eu_ai_act_001",
+    "artifact_hash": "sha256:demo-artifact-eu-ai-act-watch",
+    "usage_attribution_path": "cathedral.regulatory_intelligence.artifact_used"
+  },
+  "disqualifier_attestations": {
+    "not_legal_advice": true,
+    "no_confidential_data": true,
+    "citations_are_primary_sources": true,
+    "no_uncited_material_claims": true,
+    "does_not_count_self_usage_as_demand": true
+  }
+}

--- a/examples/regulatory-intelligence/cards.seed.json
+++ b/examples/regulatory-intelligence/cards.seed.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "cathedral.regulatory_intelligence.card_registry.v1",
+  "cards": [
+    {
+      "card_id": "eu_ai_act_watch",
+      "country": "European Union",
+      "jurisdiction_code": "EU",
+      "topic": "AI Act implementation",
+      "title": "EU AI Act implementation watch",
+      "summary": "Tracks implementation duties, guidance, dates, and obligations under the EU AI Act.",
+      "tags": ["ai_governance", "high_risk_ai", "general_purpose_ai"],
+      "required_source_ids": ["eu_ai_act_eurlex", "eu_ai_act_commission"],
+      "assigned_worker_id": "polaris_worker_reg_eu_ai_act_001",
+      "status": "active",
+      "update_cadence": "daily"
+    },
+    {
+      "card_id": "us_ai_governance_watch",
+      "country": "United States",
+      "jurisdiction_code": "US",
+      "topic": "Federal AI governance",
+      "title": "US federal AI governance watch",
+      "summary": "Tracks federal AI governance, NIST risk guidance, and safety policy signals.",
+      "tags": ["ai_governance", "federal_policy", "ai_risk"],
+      "required_source_ids": ["us_ai_eo_federal_register", "us_nist_ai_rmf"],
+      "assigned_worker_id": null,
+      "status": "open",
+      "update_cadence": "daily"
+    },
+    {
+      "card_id": "sg_ai_assurance_watch",
+      "country": "Singapore",
+      "jurisdiction_code": "SG",
+      "topic": "AI assurance",
+      "title": "Singapore AI assurance watch",
+      "summary": "Tracks AI governance, testing, and assurance frameworks from PDPC and IMDA.",
+      "tags": ["ai_governance", "assurance", "testing"],
+      "required_source_ids": ["singapore_model_ai_governance", "singapore_ai_verify"],
+      "assigned_worker_id": null,
+      "status": "open",
+      "update_cadence": "daily"
+    }
+  ]
+}

--- a/examples/regulatory-intelligence/job.sample.json
+++ b/examples/regulatory-intelligence/job.sample.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "cathedral.regulatory_intelligence.job.v1",
+  "job_id": "job_eu_ai_act_watch_2026_05_10",
+  "card_id": "eu_ai_act_watch",
+  "worker_id": "polaris_worker_reg_eu_ai_act_001",
+  "objective": "Update the EU AI Act implementation watch card from approved official sources.",
+  "source_ids": ["eu_ai_act_eurlex", "eu_ai_act_commission"],
+  "artifact_type": "regulatory_intelligence_card",
+  "due_at": "2026-05-10T23:59:00Z",
+  "status": "assigned"
+}

--- a/examples/regulatory-intelligence/source-baseline.json
+++ b/examples/regulatory-intelligence/source-baseline.json
@@ -1,0 +1,149 @@
+{
+  "schema_version": "cathedral.regulatory_intelligence.source_baseline.v1",
+  "generated_at": "2026-05-10T00:00:00Z",
+  "sources": [
+    {
+      "source_id": "eu_ai_act_eurlex",
+      "jurisdiction_code": "EU",
+      "country": "European Union",
+      "title": "Regulation (EU) 2024/1689, Artificial Intelligence Act",
+      "authority": "EUR-Lex",
+      "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689",
+      "reliability_tier": "primary_law",
+      "topic_tags": ["ai_governance", "high_risk_ai", "general_purpose_ai"],
+      "poll_cadence_days": 7
+    },
+    {
+      "source_id": "eu_ai_act_commission",
+      "jurisdiction_code": "EU",
+      "country": "European Union",
+      "title": "European Commission AI Act policy page",
+      "authority": "European Commission",
+      "url": "https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai",
+      "reliability_tier": "primary_regulator",
+      "topic_tags": ["ai_governance", "implementation", "ai_pact"],
+      "poll_cadence_days": 3
+    },
+    {
+      "source_id": "us_ai_eo_federal_register",
+      "jurisdiction_code": "US",
+      "country": "United States",
+      "title": "Executive Order 14110 on Safe, Secure, and Trustworthy AI",
+      "authority": "Federal Register",
+      "url": "https://www.federalregister.gov/documents/2023/11/01/2023-24283/safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence",
+      "reliability_tier": "primary_law",
+      "topic_tags": ["ai_governance", "federal_policy", "safety"],
+      "poll_cadence_days": 7
+    },
+    {
+      "source_id": "us_nist_ai_rmf",
+      "jurisdiction_code": "US",
+      "country": "United States",
+      "title": "NIST AI Risk Management Framework",
+      "authority": "National Institute of Standards and Technology",
+      "url": "https://www.nist.gov/itl/ai-risk-management-framework",
+      "reliability_tier": "primary_regulator",
+      "topic_tags": ["ai_risk", "assurance", "framework"],
+      "poll_cadence_days": 14
+    },
+    {
+      "source_id": "uk_ai_white_paper",
+      "jurisdiction_code": "UK",
+      "country": "United Kingdom",
+      "title": "A pro-innovation approach to AI regulation",
+      "authority": "Department for Science, Innovation and Technology",
+      "url": "https://www.gov.uk/government/publications/ai-regulation-a-pro-innovation-approach",
+      "reliability_tier": "official_policy",
+      "topic_tags": ["ai_governance", "regulatory_framework"],
+      "poll_cadence_days": 14
+    },
+    {
+      "source_id": "canada_ai_portal",
+      "jurisdiction_code": "CA",
+      "country": "Canada",
+      "title": "Canada Artificial Intelligence policies and initiatives",
+      "authority": "Government of Canada",
+      "url": "https://www.canada.ca/en/services/science/innovation/artificial-intelligence.html",
+      "reliability_tier": "official_policy",
+      "topic_tags": ["ai_governance", "aida", "compute_strategy"],
+      "poll_cadence_days": 7
+    },
+    {
+      "source_id": "singapore_model_ai_governance",
+      "jurisdiction_code": "SG",
+      "country": "Singapore",
+      "title": "Singapore Model AI Governance Framework",
+      "authority": "Personal Data Protection Commission",
+      "url": "https://www.pdpc.gov.sg/help-and-resources/2020/01/model-ai-governance-framework",
+      "reliability_tier": "primary_regulator",
+      "topic_tags": ["ai_governance", "model_framework", "personal_data"],
+      "poll_cadence_days": 14
+    },
+    {
+      "source_id": "singapore_ai_verify",
+      "jurisdiction_code": "SG",
+      "country": "Singapore",
+      "title": "AI Verify governance testing framework and toolkit launch",
+      "authority": "Personal Data Protection Commission",
+      "url": "https://www.pdpc.gov.sg/news-and-events/announcements/2022/05/launch-of-ai-verify---an-ai-governance-testing-framework-and-toolkit",
+      "reliability_tier": "primary_regulator",
+      "topic_tags": ["ai_governance", "testing", "assurance"],
+      "poll_cadence_days": 14
+    },
+    {
+      "source_id": "japan_ai_business_guidelines",
+      "jurisdiction_code": "JP",
+      "country": "Japan",
+      "title": "AI Guidelines for Business Ver. 1.0",
+      "authority": "METI and MIC",
+      "url": "https://www.meti.go.jp/english/press/2024/0419_002.html",
+      "reliability_tier": "primary_regulator",
+      "topic_tags": ["ai_governance", "business_guidelines"],
+      "poll_cadence_days": 14
+    },
+    {
+      "source_id": "india_dpdp_act",
+      "jurisdiction_code": "IN",
+      "country": "India",
+      "title": "Digital Personal Data Protection Act, 2023",
+      "authority": "India Code",
+      "url": "https://www.indiacode.nic.in/handle/123456789/22037?locale=en",
+      "reliability_tier": "primary_law",
+      "topic_tags": ["data_protection", "privacy"],
+      "poll_cadence_days": 7
+    },
+    {
+      "source_id": "australia_ai_assurance_framework",
+      "jurisdiction_code": "AU",
+      "country": "Australia",
+      "title": "National framework for the assurance of AI in government",
+      "authority": "Australian Government Department of Finance",
+      "url": "https://www.finance.gov.au/government/public-data/data-and-digital-ministers-meeting/national-framework-assurance-artificial-intelligence-government",
+      "reliability_tier": "primary_regulator",
+      "topic_tags": ["ai_assurance", "government_use", "ethics"],
+      "poll_cadence_days": 14
+    },
+    {
+      "source_id": "uae_ai_strategy",
+      "jurisdiction_code": "AE",
+      "country": "United Arab Emirates",
+      "title": "UAE National Strategy for Artificial Intelligence 2031",
+      "authority": "UAE Artificial Intelligence Office",
+      "url": "https://ai.gov.ae/strategy/",
+      "reliability_tier": "official_policy",
+      "topic_tags": ["ai_strategy", "government_services"],
+      "poll_cadence_days": 30
+    },
+    {
+      "source_id": "china_generative_ai_interim_measures",
+      "jurisdiction_code": "CN",
+      "country": "China",
+      "title": "Interim Measures for the Management of Generative AI Services",
+      "authority": "Cyberspace Administration of China",
+      "url": "http://www.cac.gov.cn/2023-07/13/c_1690898327029107.htm",
+      "reliability_tier": "primary_regulator",
+      "topic_tags": ["generative_ai", "ai_governance", "platform_compliance"],
+      "poll_cadence_days": 14
+    }
+  ]
+}

--- a/examples/regulatory-intelligence/worker.sample.json
+++ b/examples/regulatory-intelligence/worker.sample.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "cathedral.regulatory_intelligence.worker.v1",
+  "worker_id": "polaris_worker_reg_eu_ai_act_001",
+  "uid": 39,
+  "wallet": "5F_cathedral_demo_worker",
+  "runtime": "hermes",
+  "category": "regulatory_intelligence",
+  "endpoint": "https://polaris.example/workers/polaris_worker_reg_eu_ai_act_001",
+  "capabilities": ["research", "summarize", "cite_sources", "daily_update"],
+  "assigned_card_ids": ["eu_ai_act_watch"],
+  "config_version": "v1.0.0",
+  "status": "active",
+  "reputation_score": 72.0
+}

--- a/justfile
+++ b/justfile
@@ -380,6 +380,18 @@ localnet-restart:
 cost-collapse-preflight MANIFEST="docs/cost-collapse/starter-kit/submission-manifest.example.json":
     python3 scripts/cost-collapse/preflight.py {{MANIFEST}} --root docs/cost-collapse/starter-kit
 
+# Run regulatory intelligence artifact preflight
+regulatory-preflight ARTIFACT="examples/regulatory-intelligence/artifact.sample.json":
+    python3 scripts/regulatory-intelligence/preflight.py {{ARTIFACT}}
+
+# Prove invalid regulatory fixture fails preflight
+regulatory-preflight-invalid:
+    python3 scripts/regulatory-intelligence/preflight.py examples/regulatory-intelligence/artifact.invalid.json --expect-fail
+
+# Run local regulatory intelligence e2e harness
+regulatory-e2e:
+    python3 scripts/regulatory-intelligence/run_local_e2e.py
+
 # =============================================================================
 # PYTHON SDK
 # =============================================================================

--- a/scripts/regulatory-intelligence/preflight.py
+++ b/scripts/regulatory-intelligence/preflight.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Preflight a Cathedral regulatory intelligence artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+SCHEMA_VERSION = "cathedral.regulatory_intelligence.artifact.v1"
+BASELINE_VERSION = "cathedral.regulatory_intelligence.source_baseline.v1"
+CARD_REGISTRY_VERSION = "cathedral.regulatory_intelligence.card_registry.v1"
+
+REQUIRED_TEXT_FIELDS = {
+    "title": 8,
+    "summary": 60,
+    "what_changed": 40,
+    "why_it_matters": 40,
+}
+
+REQUIRED_ATTESTATIONS = {
+    "not_legal_advice",
+    "no_confidential_data",
+    "citations_are_primary_sources",
+    "no_uncited_material_claims",
+    "does_not_count_self_usage_as_demand",
+}
+
+ELIGIBLE_SOURCE_TIERS = {
+    "primary_law",
+    "primary_regulator",
+    "official_policy",
+}
+
+
+def read_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise ValueError(f"file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}: {exc}") from exc
+
+
+def nested(data: dict, path: str):
+    current = data
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def parse_time(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def is_url(value: object, require_https: bool = True) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    parsed = urlparse(value)
+    if require_https and parsed.scheme != "https":
+        return False
+    return parsed.scheme in {"https", "http"} and bool(parsed.netloc)
+
+
+def load_sources(source_baseline: dict) -> dict[str, dict]:
+    if source_baseline.get("schema_version") != BASELINE_VERSION:
+        raise ValueError(f"source baseline schema_version must be {BASELINE_VERSION}")
+    sources = source_baseline.get("sources")
+    if not isinstance(sources, list):
+        raise ValueError("source baseline must contain sources array")
+    by_id: dict[str, dict] = {}
+    for source in sources:
+        if not isinstance(source, dict):
+            raise ValueError("each source must be an object")
+        source_id = source.get("source_id")
+        if not isinstance(source_id, str) or not source_id.strip():
+            raise ValueError("each source must have source_id")
+        by_id[source_id] = source
+    return by_id
+
+
+def load_cards(card_registry: dict) -> dict[str, dict]:
+    if card_registry.get("schema_version") != CARD_REGISTRY_VERSION:
+        raise ValueError(f"card registry schema_version must be {CARD_REGISTRY_VERSION}")
+    cards = card_registry.get("cards")
+    if not isinstance(cards, list):
+        raise ValueError("card registry must contain cards array")
+    by_id: dict[str, dict] = {}
+    for card in cards:
+        if not isinstance(card, dict):
+            raise ValueError("each card must be an object")
+        card_id = card.get("card_id")
+        if not isinstance(card_id, str) or not card_id.strip():
+            raise ValueError("each card must have card_id")
+        by_id[card_id] = card
+    return by_id
+
+
+def score_artifact(artifact: dict, card: dict, sources_by_id: dict[str, dict]) -> tuple[int, dict[str, int]]:
+    citations = artifact.get("citations") if isinstance(artifact.get("citations"), list) else []
+    citation_ids = {c.get("source_id") for c in citations if isinstance(c, dict)}
+    required_ids = set(card.get("required_source_ids", []))
+
+    required_covered = len(required_ids & citation_ids)
+    required_total = max(len(required_ids), 1)
+    source_quality = round(30 * (required_covered / required_total))
+
+    generated_at = parse_time(artifact.get("generated_at")) or datetime.now(timezone.utc)
+    fresh_count = 0
+    for citation in citations:
+        if not isinstance(citation, dict):
+            continue
+        retrieved_at = parse_time(citation.get("retrieved_at"))
+        if retrieved_at is None:
+            continue
+        age_days = abs((generated_at - retrieved_at).total_seconds()) / 86400
+        if age_days <= 7:
+            fresh_count += 1
+    freshness = round(20 * (fresh_count / max(len(citations), 1)))
+
+    text = " ".join(
+        str(artifact.get(field, ""))
+        for field in ["summary", "what_changed", "why_it_matters"]
+    )
+    has_dates = any(char.isdigit() for char in text)
+    specificity = 15 if len(text) >= 220 and has_dates else 9 if len(text) >= 160 else 4
+
+    action_items = artifact.get("action_items")
+    risks = artifact.get("risks")
+    usefulness = 20
+    if not isinstance(action_items, list) or len(action_items) < 2:
+        usefulness -= 8
+    if not isinstance(risks, list) or len(risks) < 1:
+        usefulness -= 6
+    if len(str(artifact.get("why_it_matters", ""))) < 80:
+        usefulness -= 4
+    usefulness = max(usefulness, 0)
+
+    clarity = 15
+    summary = str(artifact.get("summary", ""))
+    if len(summary) > 700:
+        clarity -= 5
+    if "legal advice" not in " ".join(str(r) for r in risks).lower():
+        clarity -= 4
+    clarity = max(clarity, 0)
+
+    parts = {
+        "source_quality": source_quality,
+        "freshness": freshness,
+        "specificity": specificity,
+        "usefulness": usefulness,
+        "clarity": clarity,
+    }
+    return sum(parts.values()), parts
+
+
+def validate_artifact(
+    artifact: dict,
+    source_baseline: dict,
+    card_registry: dict,
+) -> tuple[list[str], list[str], int, dict[str, int]]:
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    sources_by_id = load_sources(source_baseline)
+    cards_by_id = load_cards(card_registry)
+
+    if artifact.get("schema_version") != SCHEMA_VERSION:
+        failures.append(f"schema_version must be {SCHEMA_VERSION}")
+
+    card_id = artifact.get("card_id")
+    card = cards_by_id.get(card_id)
+    if not card:
+        failures.append("card_id must exist in cards.seed.json")
+        card = {}
+
+    if card and artifact.get("jurisdiction_code") != card.get("jurisdiction_code"):
+        failures.append("artifact jurisdiction_code must match assigned card")
+
+    assigned_worker = card.get("assigned_worker_id")
+    if assigned_worker and artifact.get("worker_id") != assigned_worker:
+        failures.append("worker_id must match the assigned card worker")
+
+    for field, minimum in REQUIRED_TEXT_FIELDS.items():
+        value = artifact.get(field)
+        if not isinstance(value, str) or len(value.strip()) < minimum:
+            failures.append(f"{field} must be at least {minimum} characters")
+
+    generated_at = parse_time(artifact.get("generated_at"))
+    if generated_at is None:
+        failures.append("generated_at must be an ISO timestamp")
+
+    confidence = artifact.get("confidence")
+    if not isinstance(confidence, (int, float)) or isinstance(confidence, bool) or not 0 <= confidence <= 1:
+        failures.append("confidence must be a number between 0 and 1")
+
+    if artifact.get("no_legal_advice") is not True:
+        failures.append("no_legal_advice must be true")
+
+    if artifact.get("private_data_included") is not False:
+        failures.append("private_data_included must be false")
+
+    action_items = artifact.get("action_items")
+    if not isinstance(action_items, list) or len(action_items) < 2:
+        failures.append("action_items must contain at least two items")
+
+    risks = artifact.get("risks")
+    if not isinstance(risks, list) or len(risks) < 1:
+        failures.append("risks must contain at least one item")
+
+    citations = artifact.get("citations")
+    if not isinstance(citations, list) or len(citations) < 1:
+        failures.append("citations must contain at least one citation")
+        citations = []
+
+    required_ids = set(card.get("required_source_ids", []))
+    cited_ids: set[str] = set()
+    for index, citation in enumerate(citations):
+        if not isinstance(citation, dict):
+            failures.append(f"citations[{index}] must be an object")
+            continue
+        source_id = citation.get("source_id")
+        source = sources_by_id.get(source_id)
+        if not source:
+            failures.append(f"citations[{index}].source_id is not in source baseline")
+            continue
+        cited_ids.add(source_id)
+        if source.get("reliability_tier") not in ELIGIBLE_SOURCE_TIERS:
+            failures.append(f"citations[{index}] must cite an eligible official source")
+        if source.get("jurisdiction_code") != artifact.get("jurisdiction_code"):
+            failures.append(f"citations[{index}] jurisdiction does not match artifact")
+        if citation.get("url") != source.get("url"):
+            failures.append(f"citations[{index}].url must match the source registry URL")
+        if parse_time(citation.get("retrieved_at")) is None:
+            failures.append(f"citations[{index}].retrieved_at must be an ISO timestamp")
+        note = citation.get("evidence_note")
+        if not isinstance(note, str) or len(note.strip()) < 15:
+            failures.append(f"citations[{index}].evidence_note must explain the evidence")
+
+    missing_required = sorted(required_ids - cited_ids)
+    if missing_required:
+        failures.append(f"missing required source citations: {', '.join(missing_required)}")
+
+    polaris = artifact.get("polaris")
+    if not isinstance(polaris, dict):
+        failures.append("polaris must be an object")
+    else:
+        if not is_url(polaris.get("worker_deploy_url")):
+            failures.append("polaris.worker_deploy_url must be an https URL")
+        if not isinstance(polaris.get("artifact_hash"), str) or not polaris["artifact_hash"].strip():
+            failures.append("polaris.artifact_hash is required")
+        if not isinstance(polaris.get("usage_attribution_path"), str) or not polaris["usage_attribution_path"].strip():
+            failures.append("polaris.usage_attribution_path is required")
+
+    attestations = artifact.get("disqualifier_attestations")
+    if not isinstance(attestations, dict):
+        failures.append("disqualifier_attestations must be an object")
+    else:
+        for key in sorted(REQUIRED_ATTESTATIONS):
+            if attestations.get(key) is not True:
+                failures.append(f"disqualifier_attestations.{key} must be true")
+
+    score, score_parts = score_artifact(artifact, card, sources_by_id)
+    if score < 75:
+        warnings.append(f"score is {score}, below publish threshold 75")
+    if failures:
+        warnings.append("preflight failing means the artifact is ineligible for scoring")
+
+    return failures, warnings, score, score_parts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Preflight a Cathedral regulatory intelligence artifact.")
+    parser.add_argument(
+        "artifact",
+        type=Path,
+        nargs="?",
+        default=Path("examples/regulatory-intelligence/artifact.sample.json"),
+        help="Path to artifact JSON",
+    )
+    parser.add_argument(
+        "--sources",
+        type=Path,
+        default=Path("examples/regulatory-intelligence/source-baseline.json"),
+        help="Path to source baseline JSON",
+    )
+    parser.add_argument(
+        "--cards",
+        type=Path,
+        default=Path("examples/regulatory-intelligence/cards.seed.json"),
+        help="Path to card registry JSON",
+    )
+    parser.add_argument("--expect-fail", action="store_true", help="Exit 0 only when preflight fails")
+    args = parser.parse_args()
+
+    try:
+        artifact = read_json(args.artifact)
+        sources = read_json(args.sources)
+        cards = read_json(args.cards)
+        failures, warnings, score, score_parts = validate_artifact(artifact, sources, cards)
+    except ValueError as exc:
+        print(f"FAIL {exc}", file=sys.stderr)
+        return 0 if args.expect_fail else 2
+
+    print("Cathedral regulatory intelligence preflight")
+    print(f"artifact: {args.artifact.resolve()}")
+    print(f"score: {score}")
+    for key, value in score_parts.items():
+        print(f"  {key}: {value}")
+
+    if warnings:
+        print("\nWarnings:")
+        for warning in warnings:
+            print(f"  WARN {warning}")
+
+    if failures:
+        print("\nFailures:")
+        for failure in failures:
+            print(f"  FAIL {failure}")
+        return 0 if args.expect_fail else 1
+
+    if args.expect_fail:
+        print("\nFAIL expected preflight to fail, but it passed", file=sys.stderr)
+        return 1
+
+    print("\nPASS artifact is eligible for scoring intake")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regulatory-intelligence/run_local_e2e.py
+++ b/scripts/regulatory-intelligence/run_local_e2e.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Run a local Cathedral regulatory intelligence e2e simulation."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from preflight import read_json, validate_artifact
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES = ROOT / "examples" / "regulatory-intelligence"
+TARGET = ROOT / "target" / "regulatory-intelligence"
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+def write_markdown(path: Path, report: dict) -> None:
+    lines = [
+        "# Cathedral Regulatory Intelligence E2E",
+        "",
+        f"Generated: {report['generated_at']}",
+        "",
+        "## Result",
+        "",
+        f"- status: {report['status']}",
+        f"- card: {report['card']['card_id']}",
+        f"- worker: {report['worker']['worker_id']}",
+        f"- score: {report['score']['total']}",
+        f"- reputation before: {report['reputation']['before']}",
+        f"- reputation after: {report['reputation']['after']}",
+        "",
+        "## Events",
+        "",
+    ]
+    for event in report["events"]:
+        lines.append(f"- {event['type']}: {event['detail']}")
+    lines.extend(
+        [
+            "",
+            "## Score parts",
+            "",
+        ]
+    )
+    for key, value in report["score"]["parts"].items():
+        lines.append(f"- {key}: {value}")
+    lines.extend(
+        [
+            "",
+            "## Production gaps",
+            "",
+        ]
+    )
+    for gap in report["production_gaps"]:
+        lines.append(f"- {gap}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    source_baseline = read_json(EXAMPLES / "source-baseline.json")
+    card_registry = read_json(EXAMPLES / "cards.seed.json")
+    worker = read_json(EXAMPLES / "worker.sample.json")
+    job = read_json(EXAMPLES / "job.sample.json")
+    artifact = read_json(EXAMPLES / "artifact.sample.json")
+    invalid_artifact = read_json(EXAMPLES / "artifact.invalid.json")
+
+    failures, warnings, score, score_parts = validate_artifact(artifact, source_baseline, card_registry)
+    invalid_failures, _, _, _ = validate_artifact(invalid_artifact, source_baseline, card_registry)
+
+    cards_by_id = {card["card_id"]: card for card in card_registry["cards"]}
+    card = cards_by_id[job["card_id"]]
+
+    events = [
+        {
+            "type": "worker_registered",
+            "detail": f"{worker['worker_id']} registered as a Hermes regulatory worker",
+        },
+        {
+            "type": "card_assigned",
+            "detail": f"{card['card_id']} assigned to {worker['worker_id']}",
+        },
+        {
+            "type": "job_created",
+            "detail": f"{job['job_id']} created for {card['country']} {card['topic']}",
+        },
+        {
+            "type": "artifact_submitted",
+            "detail": f"{artifact['artifact_id']} submitted with {len(artifact['citations'])} citations",
+        },
+        {
+            "type": "artifact_scored",
+            "detail": f"validator score {score}",
+        },
+    ]
+
+    reputation_before = float(worker["reputation_score"])
+    reputation_after = round((reputation_before * 0.8) + (score * 0.2), 2)
+    status = "pass" if not failures and invalid_failures else "fail"
+
+    report = {
+        "schema_version": "cathedral.regulatory_intelligence.e2e_report.v1",
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "status": status,
+        "events": events,
+        "worker": {
+            "worker_id": worker["worker_id"],
+            "runtime": worker["runtime"],
+            "category": worker["category"],
+        },
+        "card": {
+            "card_id": card["card_id"],
+            "country": card["country"],
+            "topic": card["topic"],
+            "required_source_ids": card["required_source_ids"],
+        },
+        "artifact": {
+            "artifact_id": artifact["artifact_id"],
+            "citation_count": len(artifact["citations"]),
+            "no_legal_advice": artifact["no_legal_advice"],
+            "polaris_worker_deploy_url": artifact["polaris"]["worker_deploy_url"],
+        },
+        "score": {
+            "total": score,
+            "parts": score_parts,
+            "warnings": warnings,
+            "failures": failures,
+        },
+        "invalid_fixture": {
+            "expected_failures": len(invalid_failures),
+            "passed_negative_test": bool(invalid_failures),
+        },
+        "reputation": {
+            "before": reputation_before,
+            "after": reputation_after,
+        },
+        "production_gaps": [
+            "Replace stub Polaris worker URL with a real Hermes deployment link.",
+            "Sign Polaris worker and usage events before rewards consume them.",
+            "Add live source fetch and diff checks before public reward weighting.",
+            "Connect published cards to downstream usage attribution.",
+        ],
+    }
+
+    write_json(TARGET / "e2e-report.json", report)
+    write_markdown(TARGET / "e2e-report.md", report)
+
+    print("Cathedral regulatory intelligence e2e")
+    print(f"status: {status}")
+    print(f"score: {score}")
+    print(f"worker: {worker['worker_id']}")
+    print(f"card: {card['card_id']}")
+    print(f"report: {TARGET / 'e2e-report.json'}")
+
+    if failures:
+        print("\nFailures:")
+        for failure in failures:
+            print(f"  FAIL {failure}")
+        return 1
+    if not invalid_failures:
+        print("\nFAIL invalid fixture unexpectedly passed")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the first Cathedral regulatory intelligence work unit for persistent Hermes workers that maintain country-level cards.

## Changes

- Adds miner, validator, Polaris contract, and source baseline docs.
- Adds official-source fixtures, sample card registry, worker, job, valid artifact, and invalid artifact.
- Adds validator preflight for schema, citations, source coverage, Polaris attribution, and anti-abuse attestations.
- Adds local e2e harness for worker registration, card assignment, artifact intake, scoring, and reputation update.
- Adds just commands for preflight and e2e.

## Linked follow-up issues

- #71 signed Polaris worker events
- #72 live source fetch and diff checks
- #73 usage attribution filtering before rewards

## Test plan

- `just regulatory-preflight`
- `just regulatory-preflight-invalid`
- `just regulatory-e2e`
- `cargo check --workspace`

## Notes

This is a truthful local harness. Production still needs signed Polaris events, real Hermes deploy links, live source snapshots, and reward feed integration before emissions should depend on it.